### PR TITLE
docs: document defeq and type inference related functions

### DIFF
--- a/Lean4Lean/Inductive/Reduce.lean
+++ b/Lean4Lean/Inductive/Reduce.lean
@@ -50,10 +50,11 @@ def expandEtaStruct (eType e : Expr) : Expr :=
     result := .app result (.proj I i e)
   pure result
 
-/-- When `e` is of struct type, converts it into a constructor application using projections.
+/-- When `e` is of non-recursive structure type, and that type is not a proposition, converts `e`
+into a constructor application using projections.
 
-For instance if we have `e : String`, it is converted into `String.mk (String.data e)`
-(which is definitionally equal to `e` by struct eta). -/
+For instance if we have `e : α × β`, it is converted into `Prod.mk α β e.1 e.2` (which is
+definitionally equal to `e` by struct eta). -/
 def toCtorWhenStruct (inductName : Name) (e : Expr) : m Expr := do
   if !env.isNonRecStructure inductName || (e.isConstructorApp?' env).isSome then
     return e
@@ -70,10 +71,12 @@ def getRecRuleFor (rval : RecursorVal) (major : Expr) : Option RecursorRule := d
 /-- Performs recursor reduction on `e` (returning `none` if not applicable).
 
 For recursor reduction to occur, `e` must be a recursor application where the major premise is
-either a complete constructor application or of a K- or structure-like inductive type (in which
-case it is converted into an equivalent constructor application). The reduction is done by applying
-the `RecursorRule.rhs` associated with the constructor to the parameters from the recursor
-application and the fields of the constructor application. -/
+either a complete constructor application, a `Nat` or `String` literal, or of a K- or
+structure-like inductive type (in each case it is converted into an equivalent constructor
+application). The reduction is done by applying the `RecursorRule.rhs` associated with the
+constructor to everything before the indices in the recursor application (its parameters, motives
+and minor premises) and then to the fields of the constructor application; any arguments after the
+major premise are re-applied to the result. -/
 def inductiveReduceRec [Monad m] (env : Environment) (e : Expr)
     (whnf : Expr → m Expr) (inferType : Expr → m Expr) (isDefEq : Expr → Expr → m Bool) :
     m (Option Expr) := do
@@ -94,8 +97,8 @@ def inductiveReduceRec [Monad m] (env : Environment) (e : Expr)
   if rule.nfields > majorArgs.size then return none
   if ls.length != info.levelParams.length then return none
   let mut rhs := rule.rhs.instantiateLevelParams info.levelParams ls
-  -- get parameters from recursor application (recursor rules don't need the indices,
-  -- as these are determined by the constructor and its parameters/fields)
+  -- get the parameters, motives and minor premises from the recursor application (recursor rules
+  -- don't need the indices, as these are determined by the constructor and its parameters/fields)
   rhs := mkAppRange rhs 0 info.getFirstIndexIdx recArgs
   -- get fields from constructor application
   rhs := mkAppRange rhs (majorArgs.size - rule.nfields) majorArgs.size majorArgs

--- a/Lean4Lean/Inductive/Reduce.lean
+++ b/Lean4Lean/Inductive/Reduce.lean
@@ -20,6 +20,15 @@ def mkNullaryCtor (type : Expr) (nparams : Nat) : Option Expr :=
   let name ← getFirstCtor env dName
   return mkAppRange (.const name ls) 0 nparams args
 
+/--
+When `e` has the type of a K-like inductive, converts it into a constructor
+application.
+
+For instance if we have `e : Eq a a`, it is converted into `Eq.refl a` (which
+it is definitionally equal to by proof irrelevance). Note that the indices of
+`e`'s type must match those of the constructor application (for instance,
+`e : Eq a b` cannot be converted if `a` and `b` are not defeq).
+-/
 def toCtorWhenK (rval : RecursorVal) (e : Expr) : m Expr := do
   assert! rval.k
   let appType ← whnf (← inferType e)
@@ -30,6 +39,7 @@ def toCtorWhenK (rval : RecursorVal) (e : Expr) : m Expr := do
     for h : i in [rval.numParams:appTypeArgs.size] do
       if appTypeArgs[i].hasExprMVar then return e
   let some newCtorApp := mkNullaryCtor env appType rval.numParams | return e
+  -- check that the indices of types of `e` and `newCtorApp` match
   unless ← isDefEq appType (← inferType newCtorApp) do return e
   return newCtorApp
 
@@ -43,6 +53,14 @@ def expandEtaStruct (eType e : Expr) : Expr :=
     result := .app result (.proj I i e)
   pure result
 
+/--
+When `e` is of struct type, converts it into a constructor application using
+projections.
+
+For instance if we have `e : String`, it is converted into
+`String.mk (String.data e)` (which is definitionally equal to `e` by struct
+eta).
+-/
 def toCtorWhenStruct (inductName : Name) (e : Expr) : m Expr := do
   if !env.isNonRecStructure inductName || (e.isConstructorApp?' env).isSome then
     return e
@@ -56,6 +74,16 @@ def getRecRuleFor (rval : RecursorVal) (major : Expr) : Option RecursorRule := d
   let .const fn _ := major.getAppFn | none
   rval.rules.find? (·.ctor == fn)
 
+/--
+Performs recursor reduction on `e` (returning `none` if not applicable).
+
+For recursor reduction to occur, `e` must be a recursor application where the
+major premise is either a complete constructor application or of a K- or
+structure-like inductive type (in which case it is converted into an equivalent
+constructor application). The reduction is done by applying the
+`RecursorRule.rhs` associated with the constructor to the parameters from the
+recursor application and the fields of the constructor application.
+-/
 def inductiveReduceRec [Monad m] (env : Environment) (e : Expr)
     (whnf : Expr → m Expr) (inferType : Expr → m Expr) (isDefEq : Expr → Expr → m Bool) :
     m (Option Expr) := do
@@ -76,7 +104,10 @@ def inductiveReduceRec [Monad m] (env : Environment) (e : Expr)
   if rule.nfields > majorArgs.size then return none
   if ls.length != info.levelParams.length then return none
   let mut rhs := rule.rhs.instantiateLevelParams info.levelParams ls
+  -- get parameters from recursor application (recursor rules don't need the indices,
+  -- as these are determined by the constructor and its parameters/fields)
   rhs := mkAppRange rhs 0 info.getFirstIndexIdx recArgs
+  -- get fields from constructor application
   rhs := mkAppRange rhs (majorArgs.size - rule.nfields) majorArgs.size majorArgs
   if majorIdx + 1 < recArgs.size then
     rhs := mkAppRange rhs (majorIdx + 1) recArgs.size recArgs

--- a/Lean4Lean/Inductive/Reduce.lean
+++ b/Lean4Lean/Inductive/Reduce.lean
@@ -20,15 +20,12 @@ def mkNullaryCtor (type : Expr) (nparams : Nat) : Option Expr :=
   let name ← getFirstCtor env dName
   return mkAppRange (.const name ls) 0 nparams args
 
-/--
-When `e` has the type of a K-like inductive, converts it into a constructor
-application.
+/-- When `e` has the type of a K-like inductive, converts it into a constructor application.
 
-For instance if we have `e : Eq a a`, it is converted into `Eq.refl a` (which
-it is definitionally equal to by proof irrelevance). Note that the indices of
-`e`'s type must match those of the constructor application (for instance,
-`e : Eq a b` cannot be converted if `a` and `b` are not defeq).
--/
+For instance if we have `e : Eq a a`, it is converted into `Eq.refl a` (which it is definitionally
+equal to by proof irrelevance). Note that the indices of `e`'s type must match those of the
+constructor application (for instance, `e : Eq a b` cannot be converted if `a` and `b` are not
+defeq). -/
 def toCtorWhenK (rval : RecursorVal) (e : Expr) : m Expr := do
   assert! rval.k
   let appType ← whnf (← inferType e)
@@ -53,14 +50,10 @@ def expandEtaStruct (eType e : Expr) : Expr :=
     result := .app result (.proj I i e)
   pure result
 
-/--
-When `e` is of struct type, converts it into a constructor application using
-projections.
+/-- When `e` is of struct type, converts it into a constructor application using projections.
 
-For instance if we have `e : String`, it is converted into
-`String.mk (String.data e)` (which is definitionally equal to `e` by struct
-eta).
--/
+For instance if we have `e : String`, it is converted into `String.mk (String.data e)`
+(which is definitionally equal to `e` by struct eta). -/
 def toCtorWhenStruct (inductName : Name) (e : Expr) : m Expr := do
   if !env.isNonRecStructure inductName || (e.isConstructorApp?' env).isSome then
     return e
@@ -74,16 +67,13 @@ def getRecRuleFor (rval : RecursorVal) (major : Expr) : Option RecursorRule := d
   let .const fn _ := major.getAppFn | none
   rval.rules.find? (·.ctor == fn)
 
-/--
-Performs recursor reduction on `e` (returning `none` if not applicable).
+/-- Performs recursor reduction on `e` (returning `none` if not applicable).
 
-For recursor reduction to occur, `e` must be a recursor application where the
-major premise is either a complete constructor application or of a K- or
-structure-like inductive type (in which case it is converted into an equivalent
-constructor application). The reduction is done by applying the
-`RecursorRule.rhs` associated with the constructor to the parameters from the
-recursor application and the fields of the constructor application.
--/
+For recursor reduction to occur, `e` must be a recursor application where the major premise is
+either a complete constructor application or of a K- or structure-like inductive type (in which
+case it is converted into an equivalent constructor application). The reduction is done by applying
+the `RecursorRule.rhs` associated with the constructor to the parameters from the recursor
+application and the fields of the constructor application. -/
 def inductiveReduceRec [Monad m] (env : Environment) (e : Expr)
     (whnf : Expr → m Expr) (inferType : Expr → m Expr) (isDefEq : Expr → Expr → m Bool) :
     m (Option Expr) := do

--- a/Lean4Lean/Instantiate.lean
+++ b/Lean4Lean/Instantiate.lean
@@ -5,6 +5,10 @@ import Lean.Util.InstantiateLevelParams
 namespace Lean
 namespace Expr
 
+/--
+Reduces an expression of the form (λ x₁ ... xₙ, x₁) a₁ ... aₙ aₙ₊₁ ... aₘ
+to aᵢ aₙ₊₁ ... aₘ.
+-/
 def cheapBetaReduce (e : Expr) : Expr := Id.run do
   if !e.isApp then return e
   let fn := e.getAppFn

--- a/Lean4Lean/Instantiate.lean
+++ b/Lean4Lean/Instantiate.lean
@@ -5,8 +5,10 @@ import Lean.Util.InstantiateLevelParams
 namespace Lean
 namespace Expr
 
-/-- Reduces an expression of the form `(fun x₁ ... xₙ => xᵢ) a₁ ... aₙ aₙ₊₁ ... aₘ`
-to `aᵢ aₙ₊₁ ... aₘ`. -/
+/-- Beta-reduces an application `(fun x₁ ... xₙ => b) a₁ ... aₙ aₙ₊₁ ... aₘ` in the two cases where
+no substitution is needed: to `b aₙ₊₁ ... aₘ` when `b` has no loose bound variables, and to
+`aᵢ aₙ₊₁ ... aₘ` when `b` is the bound variable `xᵢ`. In any other case `e` is returned unchanged —
+this is what makes it cheap. -/
 def cheapBetaReduce (e : Expr) : Expr := Id.run do
   if !e.isApp then return e
   let fn := e.getAppFn

--- a/Lean4Lean/Instantiate.lean
+++ b/Lean4Lean/Instantiate.lean
@@ -5,10 +5,8 @@ import Lean.Util.InstantiateLevelParams
 namespace Lean
 namespace Expr
 
-/--
-Reduces an expression of the form (λ x₁ ... xₙ, x₁) a₁ ... aₙ aₙ₊₁ ... aₘ
-to aᵢ aₙ₊₁ ... aₘ.
--/
+/-- Reduces an expression of the form `(fun x₁ ... xₙ => xᵢ) a₁ ... aₙ aₙ₊₁ ... aₘ`
+to `aᵢ aₙ₊₁ ... aₘ`. -/
 def cheapBetaReduce (e : Expr) : Expr := Id.run do
   if !e.isApp then return e
   let fn := e.getAppFn

--- a/Lean4Lean/Level.lean
+++ b/Lean4Lean/Level.lean
@@ -10,6 +10,9 @@ def forEach [Monad m] (l : Level) (f : Level → m Bool) : m Unit := do
   | .max l₁ l₂ | .imax l₁ l₂ => l₁.forEach f; l₂.forEach f
   | .zero | .param .. | .mvar .. => pure ()
 
+/--
+Returns `some n` if level parameter `n` appears in `l` and `n ∉ ps`.
+-/
 def getUndefParam (l : Level) (ps : List Name) : Option Name := Id.run do
   (·.2) <$> StateT.run (s := none) do
     l.forEach fun l => do

--- a/Lean4Lean/Level.lean
+++ b/Lean4Lean/Level.lean
@@ -10,9 +10,7 @@ def forEach [Monad m] (l : Level) (f : Level → m Bool) : m Unit := do
   | .max l₁ l₂ | .imax l₁ l₂ => l₁.forEach f; l₂.forEach f
   | .zero | .param .. | .mvar .. => pure ()
 
-/--
-Returns `some n` if level parameter `n` appears in `l` and `n ∉ ps`.
--/
+/-- Returns `some n` if level parameter `n` appears in `l` and `n ∉ ps`. -/
 def getUndefParam (l : Level) (ps : List Name) : Option Name := Id.run do
   (·.2) <$> StateT.run (s := none) do
     l.forEach fun l => do

--- a/Lean4Lean/Quot.lean
+++ b/Lean4Lean/Quot.lean
@@ -78,7 +78,7 @@ def Environment.addQuot (env : Environment) : Except Exception Environment := do
   let all_quot := (← read).mkForall #[a] <| .app β quotMk_a
   withLocalDecl `q .implicit quot_r fun q => do
   -- constant Quot.ind.{u} {α : Sort u} {r : α → α → Prop} {β : @Quot.{u} α r → Prop} :
-  --   (∀ a : α, β (@Quot.mk.{u} α r a)) → ∀ q : @Quot.{u} α r, β q */
+  --   (∀ a : α, β (@Quot.mk.{u} α r a)) → ∀ q : @Quot.{u} α r, β q
   let env := env.add <| .quotInfo {
     name := ``Quot.ind, kind := .ind, levelParams := [`u]
     type := (← read).mkForall #[α, r, β] <|
@@ -86,6 +86,23 @@ def Environment.addQuot (env : Environment) : Except Exception Environment := do
   }
   return markQuotInit env
 
+/--
+Reduces the head application of a quotient eliminator as follows:
+
+```
+Quot.lift.{u, v} {α : Sort u} {r : α → α → Prop} {β : Sort v} (f : α → β) :
+  (∀ a b : α, r a b → f a = f b) → @Quot.{u} α r → β
+
+Quot.lift f h (Quot.mk r a) ... ⟶ f a ...
+```
+
+```
+Quot.ind.{u} {α : Sort u} {r : α → α → Prop} {β : @Quot.{u} α r → Prop} :
+  (∀ a : α, β (@Quot.mk.{u} α r a)) → ∀ q : @Quot.{u} α r, β q
+
+Quot.ind p (Quot.mk r a) ... ⟶ p a ...
+```
+-/
 def quotReduceRec [Monad m] (e : Expr) (whnf : Expr → m Expr) : m (Option Expr) := do
   let .const fn _ := e.getAppFn | return none
   let cont mkPos argPos := do

--- a/Lean4Lean/Quot.lean
+++ b/Lean4Lean/Quot.lean
@@ -86,8 +86,7 @@ def Environment.addQuot (env : Environment) : Except Exception Environment := do
   }
   return markQuotInit env
 
-/--
-Reduces the head application of a quotient eliminator as follows:
+/-- Reduces the head application of a quotient eliminator as follows:
 
 ```
 Quot.lift.{u, v} {α : Sort u} {r : α → α → Prop} {β : Sort v} (f : α → β) :

--- a/Lean4Lean/TypeChecker.lean
+++ b/Lean4Lean/TypeChecker.lean
@@ -76,23 +76,38 @@ inductive ReductionStatus where
 
 namespace Inner
 
+/--
+Reduces `e` to its weak-head normal form.
+-/
 def whnf (e : Expr) : RecM Expr := fun m => m.whnf e
 
 @[inline] def withLCtx [MonadWithReaderOf LocalContext m] (lctx : LocalContext) (x : m α) : m α :=
   withReader (fun _ => lctx) x
 
+/--
+Ensures that `e` is defeq to some `e' := .sort ..`, returning `e'`. If not,
+throws an error with `s` (the expression required be a sort).
+-/
 def ensureSortCore (e s : Expr) : RecM Expr := do
   if e.isSort then return e
   let e ← whnf e
   if e.isSort then return e
   throw <| .typeExpected (← getEnv) (← getLCtx) s
 
+/--
+Ensures that `e` is defeq to some `e' := .forallE ..`, returning `e'`. If not,
+throws an error with `s := f a` (the application requiring `f` to be of
+function type).
+-/
 def ensureForallCore (e s : Expr) : RecM Expr := do
   if e.isForall then return e
   let e ← whnf e
   if e.isForall then return e
   throw <| .funExpected (← getEnv) (← getLCtx) s
 
+/--
+Checks that `l` does not contain any level parameters not found in the context `tc`.
+-/
 def checkLevel (tc : Context) (l : Level) : Except Exception Unit := do
   if let some n2 := l.getUndefParam tc.lparams then
     throw <| .other s!"invalid reference to undefined universe level parameter '{n2}'"
@@ -102,6 +117,9 @@ def inferFVar (tc : Context) (name : FVarId) : Except Exception Expr := do
     return decl.type
   throw <| .other "unknown free variable"
 
+/--
+Infers the type of `.const e ls`.
+-/
 def inferConstant (tc : Context) (name : Name) (ls : List Level) (inferOnly : Bool) :
     Except Exception Expr := do
   let e := Expr.const name ls
@@ -121,8 +139,17 @@ def inferConstant (tc : Context) (name : Name) (ls : List Level) (inferOnly : Bo
       checkLevel tc l
   return info.instantiateTypeLevelParams ls
 
+/--
+Infers the type of expression `e`. If `inferOnly := false`, this function will
+throw an error if and only if `e` is not typeable according to Lean's
+algorithmic typing judgment. Setting `inferOnly := true` optimizes to avoid
+unnecessary checks in the case that `e` is already known to be well-typed.
+-/
 def inferType (e : Expr) (inferOnly := true) : RecM Expr := fun m => m.inferType e inferOnly
 
+/--
+Infers the type of lambda expression `e`.
+-/
 def inferLambda (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
   loop fvars : Expr → RecM Expr
   | .lam name dom body bi => do
@@ -137,6 +164,9 @@ def inferLambda (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
     let r := r.cheapBetaReduce
     return (← getLCtx).mkForall fvars r
 
+/--
+Infers the type of for-all expression `e`.
+-/
 def inferForall (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] #[] e where
   loop fvars us : Expr → RecM Expr
   | .forallE name dom body bi => do
@@ -150,14 +180,29 @@ def inferForall (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] #[] e wher
     let s ← ensureSortCore r e
     return .sort <| us.foldr mkLevelIMax' s.sortLevel!
 
+/--
+Returns whether `t` and `s` are definitionally equal according to Lean's
+algorithmic definitional equality judgment.
+
+NOTE: This function does not do any typechecking of its own on `t` and `s`.
+So, when this is used as part of a typechecking routine, it is expected that
+they are already well-typed (that is, that `check t` and `check s`
+did not/would not throw an error). This ensures in particular that any calls to
+`inferType e (inferOnly := false)` on subterms `e` would not fail, so we know
+that `e` types as the return value of `inferType e (inferOnly := true)`.
+-/
 def isDefEqCore (t s : Expr) : RecM Bool := fun m => m.isDefEqCore t s
 
+@[inherit_doc isDefEqCore]
 def isDefEq (t s : Expr) : RecM Bool := do
   let r ← isDefEqCore t s
   if r then
     modify fun st => { st with eqvManager := st.eqvManager.addEquiv t s }
   pure r
 
+/--
+Infers the type of application `e`, assuming that `e` is already well-typed.
+-/
 def inferApp (e : Expr) : RecM Expr := do
   e.withApp fun f args =>
   let rec loop fType j i : RecM Expr :=
@@ -172,6 +217,9 @@ def inferApp (e : Expr) : RecM Expr := do
       return fType.instantiateRevRange j args.size args
   do loop (← inferType f) 0 0
 
+/--
+Infers the type of let-expression `e`.
+-/
 def inferLet (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
   loop fvars : Expr → RecM Expr
   | .letE name type val body _ => do
@@ -189,12 +237,21 @@ def inferLet (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
     let r := r.cheapBetaReduce
     return (← getLCtx).mkForall fvars r
 
+/--
+Gets the universe level of the sort that `e`'s type is defeq to, failing if `e` is not a type.
+-/
 def getSortLevel (e : Expr) : RecM Level := do
   let .sort u ← ensureSortCore (← inferType e) e | unreachable!
   return u
 
+/--
+Checks if `e` is a proposition, that is, if its type is a sort whose level normalizes to zero.
+-/
 def isProp (e : Expr) : RecM Bool := return (← getSortLevel e).isAlwaysZero
 
+/--
+Infers the type of structure projection `e`.
+-/
 def inferProj (typeName : Name) (idx : Nat) (struct structType : Expr) : RecM Expr := do
   let e := Expr.proj typeName idx struct
   let type ← whnf structType
@@ -215,6 +272,7 @@ def inferProj (typeName : Name) (idx : Nat) (struct structType : Expr) : RecM Ex
   for i in [:idx] do
     let .forallE _ dom b _ ← whnf r | fail
     if b.hasLooseBVars then
+      -- prop structs cannot have non-prop dependent fields
       if maybePropType then if !(← isProp dom) then fail
       r := b.instantiate1 (.proj I_name i struct)
     else
@@ -223,6 +281,7 @@ def inferProj (typeName : Name) (idx : Nat) (struct structType : Expr) : RecM Ex
   if maybePropType then if !(← isProp dom) then fail
   return dom
 
+@[inherit_doc inferType]
 def inferType' (e : Expr) (inferOnly : Bool) : RecM Expr := do
   if e.hasLooseBVars then
     throw <| .other
@@ -257,6 +316,8 @@ def inferType' (e : Expr) (inferOnly : Bool) : RecM Expr := do
         let fType ← ensureForallCore (← inferType' f inferOnly) e
         let aType ← inferType' a inferOnly
         let dType := fType.bindingDomain!
+        -- it can be shown that if `e` is typeable as `T`, then `T` is typeable as `Sort l`
+        -- for some universe level `l`, so this use of `isDefEq` is valid
         let ok ← if a.isAppOfArity ``eagerReduce 2 then
           withTheReader Context (fun s => {s with eagerReduce := true}) <|
             isDefEq dType aType
@@ -270,6 +331,19 @@ def inferType' (e : Expr) (inferOnly : Bool) : RecM Expr := do
     { s with inferTypeC := s.inferTypeC.insert e r }
   return r
 
+/--
+Reduces `e` to its weak-head normal form, without unfolding definitions. This
+is a conservative version of `whnf` (which does unfold definitions), to be used
+for efficiency purposes.
+
+Setting `cheapRec` or `cheapProj` to `true` will cause the major premise/struct
+argument to be reduced "lazily" (using `whnfCore` rather than `whnf`) when
+reducing recursor applications/struct projections. This can be a useful
+optimization if we're checking the definitional equality of two recursor
+applications/struct projections of the same recursor/projection, where we
+might save some work by directly checking if the major premises/struct
+arguments are defeq (rather than eagerly applying a recursor rule/projection).
+-/
 def whnfCore (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
   fun m => m.whnfCore e cheapRec cheapProj
 
@@ -283,11 +357,20 @@ def reduceRecursor (e : Expr) (cheapRec := false) (cheapProj := false) : RecM (O
     return r
   return none
 
+/--
+Gets the weak-head normal form of the free variable `e`, which is the weak-head
+normal form of its definition if `e` is a let variable and itself if it is a
+lambda variable.
+-/
 def whnfFVar (e : Expr) (cheapRec cheapProj : Bool) : RecM Expr := do
   if let some (.ldecl (value := v) ..) := (← getLCtx).find? e.fvarId! then
     return ← whnfCore v cheapRec cheapProj
   return e
 
+/--
+Reduces a projection of `struct` at index `idx` (when `struct` is reducible to a
+constructor application).
+-/
 def reduceProj (idx : Nat) (struct : Expr) (cheapRec cheapProj : Bool) : RecM (Option Expr) := do
   let mut c ← (if cheapProj then whnfCore struct cheapRec cheapProj else whnf struct)
   if let .lit (.strVal s) := c then
@@ -301,6 +384,7 @@ def reduceProj (idx : Nat) (struct : Expr) (cheapRec cheapProj : Bool) : RecM (O
 def isLetFVar (lctx : LocalContext) (fvar : FVarId) : Bool :=
   lctx.find? fvar matches some (.ldecl ..)
 
+@[inherit_doc whnfCore]
 def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr := do
   match e with
   | .bvar .. | .sort .. | .mvar .. | .forallE .. | .const .. | .lam .. | .lit .. => return e
@@ -317,8 +401,9 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
   | .bvar .. | .sort .. | .mvar .. | .forallE .. | .const .. | .lam .. | .lit ..
   | .mdata .. => unreachable!
   | .fvar _ => return ← whnfFVar e cheapRec cheapProj
-  | .app .. =>
+  | .app .. => -- beta-reduce at the head as much as possible, apply any remaining `rargs` to the resulting expression, and re-run `whnfCore`
     e.withAppRev fun f0 rargs => do
+    -- the head may still be a let variable/binding, projection, or mdata-wrapped expression
     let f ← whnfCore f0 cheapRec cheapProj
     if let .lam _ _ body _ := f then
       let rec loop m (f : Expr) : RecM Expr :=
@@ -338,6 +423,7 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
         pure e
     else
       let r := f.mkAppRevRange 0 rargs.size rargs
+      -- FIXME(kernel) guard with reduceRecursor (as in the previous case)? adding arguments can only result in further normalization if the head reduced to a partial recursor application
       save <|← whnfCore r cheapRec cheapProj
   | .letE _ _ val body _ =>
     save <|← whnfCore (body.instantiate1 val) cheapRec cheapProj
@@ -347,6 +433,10 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
     else
       save e
 
+/--
+Checks if `e` has a head constant that can be delta-reduced (that is, it is a
+theorem or definition), returning its `ConstantInfo` if so.
+-/
 def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
   if let .const c ls := e.getAppFn then
     if let some ci := env.find? c then
@@ -357,6 +447,11 @@ def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
 def instantiateDeltaValue (ci : ConstantInfo) (ls : List Level) : Expr :=
   ci.deltaValue?.get!.instantiateLevelParams ci.levelParams ls
 
+/--
+Checks if `e` has a head constant that can be delta-reduced (that is, it is a
+theorem or definition), returning its value (instantiated by level parameters)
+if so.
+-/
 def unfoldDefinitionCore (e : Expr) : RecM (Option Expr) := do
   let .const _ ls := e | return none
   let env ← getEnv
@@ -367,6 +462,10 @@ def unfoldDefinitionCore (e : Expr) : RecM (Option Expr) := do
   modify fun s => { s with unfold := s.unfold.insert e r }
   return some r
 
+/--
+Unfolds the definition at the head of the application `e` (or `e` itself if it
+is not an application).
+-/
 def unfoldDefinition (e : Expr) : RecM (Option Expr) := do
   if e.isApp then
     let f0 := e.getAppFn
@@ -386,6 +485,12 @@ def reduceNative (_env : Environment) (e : Expr) : Except Exception (Option Expr
 
 def rawNatLitExt? (e : Expr) : Option Nat := if e == .natZero then some 0 else e.rawNatLit?
 
+/--
+Reduces the application `f a b` to a Nat literal if `a` and `b` can be reduced
+to Nat literals.
+
+Note: `f` should have an (efficient) external implementation.
+-/
 def reduceBinNatOp (f : Nat → Nat → Nat) (a b : Expr) : RecM (Option Expr) := do
   let some v1 := rawNatLitExt? (← whnf a) | return none
   let some v2 := rawNatLitExt? (← whnf b) | return none
@@ -399,11 +504,23 @@ def reducePow (a b : Expr) : RecM (Option Expr) := do
   if v2 > reducePowMaxExp then return none
   return some <| .lit <| .natVal <| Nat.pow v1 v2
 
+/--
+Reduces the application `f a b` to a boolean expression if `a` and `b` can be
+reduced to Nat literals.
+
+Note: `f` should have an (efficient) external implementation.
+-/
 def reduceBinNatPred (f : Nat → Nat → Bool) (a b : Expr) : RecM (Option Expr) := do
   let some v1 := rawNatLitExt? (← whnf a) | return none
   let some v2 := rawNatLitExt? (← whnf b) | return none
   return toExpr <| f v1 v2
 
+/--
+Reduces `e` to a natural number literal if possible, where binary operations
+and predicates may be applied (provided they have an external implementation).
+These include: `Nat.add`, `Nat.sub`, `Nat.mul`, `Nat.pow`, `Nat.gcd`,
+`Nat.mod`, `Nat.div`, `Nat.beq`, `Nat.ble`.
+-/
 def reduceNat (e : Expr) : RecM (Option Expr) := do
   let nargs := e.getAppNumArgs
   if nargs == 1 then
@@ -429,6 +546,7 @@ def reduceNat (e : Expr) : RecM (Option Expr) := do
     if f == ``Nat.shiftRight then return ← reduceBinNatOp Nat.shiftRight a b
   return none
 
+@[inherit_doc whnf]
 def whnf' (e : Expr) : RecM Expr := do
   -- Do not cache easy cases
   match e with
@@ -455,6 +573,12 @@ def whnf' (e : Expr) : RecM Expr := do
   modify fun s => { s with whnfCache := s.whnfCache.insert e r }
   return r
 
+/--
+If `t` and `s` are lambda expressions, checks that their domains are defeq and
+recurses on the bodies, substituting in a new free variable for that binder
+(this substitution is delayed for efficiency purposes using the `subst`
+parameter). Otherwise, does a normal defeq check.
+-/
 def isDefEqLambda (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
   match t, s with
   | .lam _ tDom tBody _, .lam name sDom sBody bi => do
@@ -471,6 +595,12 @@ def isDefEqLambda (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
       isDefEqLambda tBody sBody (subst.push default)
   | t, s => isDefEq (t.instantiateRev subst) (s.instantiateRev subst)
 
+/--
+If `t` and `s` are for-all expressions, checks that their domains are defeq and
+recurses on the bodies, substituting in a new free variable for that binder
+(this substitution is delayed for efficiency purposes using the `subst`
+parameter). Otherwise, does a normal defeq check.
+-/
 def isDefEqForall (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
   match t, s with
   | .forallE _ tDom tBody _, .forallE name sDom sBody bi => do
@@ -487,7 +617,16 @@ def isDefEqForall (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
       isDefEqForall tBody sBody (subst.push default)
   | t, s => isDefEq (t.instantiateRev subst) (s.instantiateRev subst)
 
+/--
+Checks that `t` and `s` are definitionally equal if:
+- they are α-equivalent
+- they have matching head constructors and are not (non-α-equivalent)
+  projections or applications
+- they have previously been checked for definitional equality
+Otherwise, defers to the calling function.
+-/
 def quickIsDefEq (t s : Expr) (useHash := false) : RecM LBool := do
+  -- optimization for terms that are already α-equivalent or were previously checked
   if ← modifyGet fun (.mk a1 a2 a3 a4 a5 a6 a7 (eqvManager := m)) =>
     let (b, m) := m.isEquiv useHash t s
     (b, .mk a1 a2 a3 a4 a5 a6 a7 (eqvManager := m))
@@ -501,6 +640,11 @@ def quickIsDefEq (t s : Expr) (useHash := false) : RecM LBool := do
   | .lit a1, .lit a2 => pure (a1 == a2).toLBool
   | _, _ => return .undef
 
+/--
+Assuming that `t` and `s` have the same function heads, returns true if they
+are applications with definitionally equal arguments (in which case they are
+defeq), and false otherwise (deferring further defeq checking to caller).
+-/
 def isDefEqArgs (t s : Expr) : RecM Bool := do
   match t, s with
   | .app tf ta, .app sf sa =>
@@ -509,15 +653,31 @@ def isDefEqArgs (t s : Expr) : RecM Bool := do
   | .app .., _ | _, .app .. => return false
   | _, _ => return true
 
+/--
+Assuming `t` and `s` are WHNF, checks if they are defeq on account of `t` being
+an η-expansion of `s`.
+
+Assuming that `s` has a function type `(x : A) -> B x`, it η-expands to
+`fun (x : A) => s x` (which it is definitionally equal to by the η rule).
+-/
 def tryEtaExpansionCore (t s : Expr) : RecM Bool := do
   if t.isLambda && !s.isLambda then
     let .forallE name ty _ bi ← whnf (← inferType s) | return false
     isDefEq t (.lam name ty (.app s (.bvar 0)) bi)
   else return false
 
+@[inherit_doc tryEtaExpansionCore]
 def tryEtaExpansion (t s : Expr) : RecM Bool :=
   tryEtaExpansionCore t s <||> tryEtaExpansionCore s t
 
+/--
+Assuming `t` and `s` in WHNF, checks if they are defeq on account of `s` being
+defeq to the struct-η-expansion of `t`.
+
+Assuming that `t` has a struct type `S`, constructor `S.mk`, and projection
+functions `pᵢ : S → Tᵢ`, it struct-η-expands to `S.mk (p₁ t) ... (pₙ t)` (which
+it is definitionally equal to by the struct-η rule).
+-/
 def tryEtaStructCore (t s : Expr) : RecM Bool := do
   let .const f _ := s.getAppFn | return false
   let env ← getEnv
@@ -527,12 +687,21 @@ def tryEtaStructCore (t s : Expr) : RecM Bool := do
   unless ← isDefEq (← inferType t) (← inferType s) do return false
   let args := s.getAppArgs
   for h : i in [fInfo.numParams:args.size] do
+    -- since `t` is in WHNF, and assuming it is not a constructor application, this projection cannot reduce
+    -- (so we are directly checking if `s` is defeq to the struct-η-expansion of `t`)
     unless ← isDefEq (.proj fInfo.induct (i - fInfo.numParams) t) args[i] do return false
   return true
 
+@[inherit_doc tryEtaStructCore]
 def tryEtaStruct (t s : Expr) : RecM Bool :=
+  -- FIXME(kernel) can return false if `t` and `s` are both constructor applications
+  -- (we have already called `isDefEqApp` on them, which returned false)
   tryEtaStructCore t s <||> tryEtaStructCore s t
 
+/--
+Checks if applications `t` and `s` (should be WHNF) are defeq on account of
+their function heads and arguments being defeq.
+-/
 def isDefEqApp (t s : Expr) : RecM Bool := do
   unless t.isApp && s.isApp do return false
   t.withApp fun tf tArgs =>
@@ -547,6 +716,10 @@ def isDefEqApp (t s : Expr) : RecM Bool := do
     loop 0
   else return false
 
+/--
+Checks if `t` and `s` are definitionally equivalent according to proof irrelevance
+(that is, they are proofs of the same proposition).
+-/
 def isDefEqProofIrrel (t s : Expr) : RecM LBool := do
   let tType ← inferType t
   if !(← isProp tType) then return .undef
@@ -570,6 +743,19 @@ def tryUnfoldProjApp (e : Expr) : RecM (Option Expr) := do
   let e' ← whnfCore e
   return if e' != e then e' else none
 
+/--
+Performs a single step of δ-reduction on `tn`, `sn`, or both (according to
+optimizations) followed by weak-head normalization (without further
+δ-reduction). If the resulting terms have matching head constructors (excluding
+non-α-equivalent applications and projections), or are applications with the
+same defined constant function head and defeq args, returns whether `tn` and
+`sn` are defeq. Otherwise, a return value indicates to the calling
+`lazyDeltaReduction` that δ-reduction is to be continued.
+
+If δ-reduction+weak-head-normalization cannot be continued (i.e. we have a
+weak-head normal form (with cheapProj := true)), defers further defeq-checking
+to `isDefEq`.
+-/
 def lazyDeltaReductionStep (tn sn : Expr) : RecM ReductionStatus := do
   let env ← getEnv
   let delta e := do whnfCore (← unfoldDefinition e).get! (cheapProj := true)
@@ -581,6 +767,7 @@ def lazyDeltaReductionStep (tn sn : Expr) : RecM ReductionStatus := do
   match isDelta env tn, isDelta env sn with
   | none, none => return .unknown tn sn
   | some _, none =>
+    -- FIXME(kernel) hasn't whnfCore already been called on sn? so when would this case arise?
     if let some sn' ← tryUnfoldProjApp sn then
       cont tn sn'
     else
@@ -615,6 +802,11 @@ def isNatSuccOf? : Expr → Option Expr
   | .app (.const ``Nat.succ _) e => return e
   | _ => none
 
+/--
+If `t` and `s` are both successors of natural numbers `t'` and `s'`, either as
+literals or `Nat.succ` applications, checks that `t'` and `s'` are
+definitionally equal. Otherwise, defers to the calling function.
+-/
 def isDefEqOffset (t s : Expr) : RecM LBool := do
   if isNatZero t && isNatZero s then
     return .true
@@ -622,6 +814,15 @@ def isDefEqOffset (t s : Expr) : RecM LBool := do
   | some t', some s' => toLBoolM <| isDefEqCore t' s'
   | _, _ => return .undef
 
+/--
+Returns whether the `cheapProj := true` weak-head normal forms of `tn` and
+`sn` are defeq if:
+- they have matching head constructors (excluding non-α-equivalent applications
+  and projections)
+- they're both natural number successors (as literals or `Nat.succ` applications)
+- one of them can be converted to a natural number/boolean literal.
+Otherwise, defers to the calling function with these normal forms.
+-/
 def lazyDeltaReduction (tn sn : Expr) : RecM ReductionStatus := do
   loop tn sn (← readThe Context).fuel.lazyDelta
 where
@@ -644,17 +845,27 @@ where
     | .continue tn sn => loop tn sn fuel
     | r => return r
 
+/--
+If `t` is a string literal and `s` is a string constructor application,
+checks that they are defeq after turning `t` into a constructor application.
+Otherwise, defers to the calling function.
+-/
 def tryStringLitExpansionCore (t s : Expr) : RecM LBool := do
   let .lit (.strVal st) := t | return .undef
   let .app sf _ := s | return .undef
   unless sf == .const ``String.ofList [] do return .undef
   toLBoolM <| isDefEqCore (.strLitToConstructor st) s
 
+@[inherit_doc tryStringLitExpansionCore]
 def tryStringLitExpansion (t s : Expr) : RecM LBool := do
   match ← tryStringLitExpansionCore t s with
   | .undef => tryStringLitExpansionCore s t
   | r => return r
 
+/--
+Checks if `t` and `s` are defeq on account of both being of a unit type (a type
+with one constructor without any fields or indices).
+-/
 def isDefEqUnitLike (t s : Expr) : RecM Bool := do
   let tType ← whnf (← inferType t)
   let .const I _ := tType.getAppFn | return false
@@ -664,6 +875,7 @@ def isDefEqUnitLike (t s : Expr) : RecM Bool := do
   let .ctorInfo { numFields := 0, .. } ← env.get c | return false
   isDefEqCore tType (← inferType s)
 
+@[inherit_doc isDefEqCore]
 def isDefEqCore' (t s : Expr) : RecM Bool := do
   let r ← quickIsDefEq t s (useHash := true)
   if r != .undef then return r == .true
@@ -691,14 +903,18 @@ def isDefEqCore' (t s : Expr) : RecM Bool := do
     if tf == sf && Level.isEquivList tl sl then return true
   | .fvar tv, .fvar sv => if tv == sv then return true
   | .proj _ ti te, .proj _ si se =>
+    -- optimized by the previous reduction functions using `cheapProj = true`
     if ti == si then if ← isDefEq te se then return true
   | _, _ => pure ()
 
+  -- the previous reduction functions used `cheapProj = true`, so we may not have a complete WHNF
   let tnn ← whnfCore tn
   let snn ← whnfCore sn
   if !(ptrEqExpr tnn tn && ptrEqExpr snn sn) then
+    -- if projection reduced, need to re-run (as we may not have a WHNF)
     return ← isDefEqCore tnn snn
 
+  -- tn and sn are both in WHNF
   if ← isDefEqApp tn sn then return true
   if ← tryEtaExpansion tn sn then return true
   if ← tryEtaStruct tn sn then return true
@@ -723,6 +939,9 @@ def Methods.withFuel : Nat → Methods
       whnf := fun e => whnf' e (withFuel n)
       inferType := fun e i => inferType' e i (withFuel n) }
 
+/--
+Runs `x` with a limit on the recursion depth.
+-/
 def RecM.run (x : RecM α) : M α := do x (Methods.withFuel (← readThe Context).fuel.recDepth)
 
 def RecM.runTermElab (x : RecM α) (safety := DefinitionSafety.safe) : Elab.Term.TermElabM α :=
@@ -730,24 +949,43 @@ def RecM.runTermElab (x : RecM α) (safety := DefinitionSafety.safe) : Elab.Term
 
 instance : MonadLift RecM Elab.Term.TermElabM := ⟨RecM.runTermElab⟩
 
+@[inherit_doc whnf']
 def whnf (e : Expr) : M Expr := (Inner.whnf e).run
 
 def whnfCore (e : Expr) : M Expr := (Inner.whnfCore e).run
 
 def unfoldDefinition (e : Expr) : M Expr := return (← (Inner.unfoldDefinition e).run).getD e
 
+/--
+Infers the type of expression `e`. Note that this uses the optimization
+`inferOnly := true`, and so should only be used for the purpose of type
+inference on terms that are known to be well-typed. To typecheck terms for the
+first time, use `checkType`.
+-/
 def inferType (e : Expr) : M Expr := (Inner.inferType e).run
 
+/--
+Infers the type of expression `e` and checks that `e` is well-typed according to Lean's typing judgment.
+
+Use `inferType` to infer type alone.
+-/
 def checkType (e : Expr) : M Expr := (Inner.inferType e (inferOnly := false)).run
 
+@[inherit_doc isDefEqCore]
 def isDefEq (t s : Expr) : M Bool := (Inner.isDefEq t s).run
 
+@[inherit_doc Inner.isProp]
 def isProp (t : Expr) : M Bool := (Inner.isProp t).run
 
+@[inherit_doc ensureSortCore]
 def ensureSort (t : Expr) (s := t) : M Expr := (ensureSortCore t s).run
 
+@[inherit_doc ensureForallCore]
 def ensureForall (t : Expr) (s := t) : M Expr := (ensureForallCore t s).run
 
+/--
+Ensures that `e` is a type/proposition. If it is not, throws an error.
+-/
 def ensureType (e : Expr) : M Expr := do ensureSort (← inferType e) e
 
 def etaExpand (e : Expr) : M Expr :=

--- a/Lean4Lean/TypeChecker.lean
+++ b/Lean4Lean/TypeChecker.lean
@@ -128,10 +128,11 @@ def inferConstant (tc : Context) (name : Name) (ls : List Level) (inferOnly : Bo
       checkLevel tc l
   return info.instantiateTypeLevelParams ls
 
-/-- Infers the type of expression `e`. If `inferOnly := false`, this function will throw an error
-if and only if `e` is not typeable according to Lean's algorithmic typing judgment. Setting
-`inferOnly := true` optimizes to avoid unnecessary checks in the case that `e` is already known to
-be well-typed. -/
+/-- Infers the type of expression `e`. If `inferOnly := false`, this function throws an error
+whenever `e` is not typeable according to Lean's algorithmic typing judgment (barring resource
+exhaustion: it may also throw `.deterministicTimeout` or `.deepRecursion` on a typeable term).
+Setting `inferOnly := true` optimizes to avoid unnecessary checks in the case that `e` is already
+known to be well-typed. -/
 def inferType (e : Expr) (inferOnly := true) : RecM Expr := fun m => m.inferType e inferOnly
 
 /-- Infers the type of lambda expression `e`. -/
@@ -168,9 +169,9 @@ definitional equality judgment.
 
 NOTE: This function does not do any typechecking of its own on `t` and `s`. So, when this is used as
 part of a typechecking routine, it is expected that they are already well-typed (that is, that
-`check t` and `check s` did not/would not throw an error). This ensures in particular that any calls
-to `inferType e (inferOnly := false)` on subterms `e` would not fail, so we know that `e` types as
-the return value of `inferType e (inferOnly := true)`. -/
+`checkType t` and `checkType s` did not/would not throw an error). This is what justifies the
+internal uses of `inferType` at its default `inferOnly := true`: on a well-typed subterm the fast
+path returns the same type the checking path would have. -/
 def isDefEqCore (t s : Expr) : RecM Bool := fun m => m.isDefEqCore t s
 
 @[inherit_doc isDefEqCore]
@@ -308,10 +309,14 @@ version of `whnf` (which does unfold definitions), to be used for efficiency pur
 
 Setting `cheapRec` or `cheapProj` to `true` will cause the major premise/struct argument to be
 reduced "lazily" (using `whnfCore` rather than `whnf`) when reducing recursor applications/struct
-projections. This can be a useful optimization if we're checking the definitional equality of two
-recursor applications/struct projections of the same recursor/projection, where we might save some
-work by directly checking if the major premises/struct arguments are defeq (rather than eagerly
-applying a recursor rule/projection). -/
+projections, and suppresses caching of the result. This can be a useful optimization if we're
+checking the definitional equality of two recursor applications/struct projections of the same
+recursor/projection, where we might save some work by directly checking if the major premises/struct
+arguments are defeq (rather than eagerly applying a recursor rule/projection).
+
+In practice only `cheapProj` is ever set. `cheapRec` is threaded through to mirror the kernel, where
+it has been dead since lean4#9275 removed the old compiler: its one caller was `csimp`, through the
+`whnf_core_cheap` wrapper that still exists but is now unused. -/
 def whnfCore (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
   fun m => m.whnfCore e cheapRec cheapProj
 
@@ -325,8 +330,8 @@ def reduceRecursor (e : Expr) (cheapRec := false) (cheapProj := false) : RecM (O
     return r
   return none
 
-/-- Gets the weak-head normal form of the free variable `e`, which is the weak-head normal form of
-its definition if `e` is a let variable and itself if it is a lambda variable. -/
+/-- Reduces the free variable `e`: to the `whnfCore` of its definition if `e` is a let variable,
+and to itself if it is a lambda variable. -/
 def whnfFVar (e : Expr) (cheapRec cheapProj : Bool) : RecM Expr := do
   if let some (.ldecl (value := v) ..) := (← getLCtx).find? e.fvarId! then
     return ← whnfCore v cheapRec cheapProj
@@ -388,9 +393,9 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
         pure e
     else
       let r := f.mkAppRevRange 0 rargs.size rargs
-      -- FIXME(kernel) guard with `reduceRecursor` (as in the previous case)? adding arguments
-      -- can only result in further normalization if the head reduced to a partial recursor
-      -- application
+      -- the recursive call re-decomposes `r` and reaches the `f == f0` branch above, so
+      -- `reduceRecursor` is still applied; adding arguments can only enable further normalization
+      -- if the head reduced to a partial recursor application
       save <|← whnfCore r cheapRec cheapProj
   | .letE _ _ val body _ =>
     save <|← whnfCore (body.instantiate1 val) cheapRec cheapProj
@@ -400,8 +405,9 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
     else
       save e
 
-/-- Checks if `e` has a head constant that can be delta-reduced (that is, it is a theorem or
-definition), returning its `ConstantInfo` if so. -/
+/-- Checks if the head of `e` is a constant that can be delta-reduced, applied to the right number
+of universe levels, returning its `ConstantInfo` if so. See `ConstantInfo.deltaValue?` for which
+constants qualify. -/
 def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
   if let .const c ls := e.getAppFn then
     if let some ci := env.find? c then
@@ -412,8 +418,9 @@ def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
 def instantiateDeltaValue (ci : ConstantInfo) (ls : List Level) : Expr :=
   ci.deltaValue?.get!.instantiateLevelParams ci.levelParams ls
 
-/-- Checks if `e` has a head constant that can be delta-reduced (that is, it is a theorem or
-definition), returning its value (instantiated by level parameters) if so. -/
+/-- If `e` is itself a constant that can be delta-reduced, returns its value with the constant's
+level parameters instantiated. Unlike `unfoldDefinition`, this does not look through applications:
+`e` must be a `.const`. -/
 def unfoldDefinitionCore (e : Expr) : RecM (Option Expr) := do
   let .const _ ls := e | return none
   let env ← getEnv
@@ -470,9 +477,11 @@ def reduceBinNatPred (f : Nat → Nat → Bool) (a b : Expr) : RecM (Option Expr
   let some v2 := rawNatLitExt? (← whnf b) | return none
   return toExpr <| f v1 v2
 
-/-- Reduces `e` to a natural number literal if possible, where binary operations and predicates may
-be applied (provided they have an external implementation). These include: `Nat.add`, `Nat.sub`,
-`Nat.mul`, `Nat.pow`, `Nat.gcd`, `Nat.mod`, `Nat.div`, `Nat.beq`, `Nat.ble`. -/
+/-- Reduces `e` to a literal if possible, where the unary operation `Nat.succ` and the binary
+operations and predicates with an external implementation may be applied: `Nat.add`, `Nat.sub`,
+`Nat.mul`, `Nat.pow`, `Nat.gcd`, `Nat.mod`, `Nat.div`, `Nat.land`, `Nat.lor`, `Nat.xor`,
+`Nat.shiftLeft`, `Nat.shiftRight` produce a `Nat` literal, while the predicates `Nat.beq` and
+`Nat.ble` produce a `Bool` literal. -/
 def reduceNat (e : Expr) : RecM (Option Expr) := do
   let nargs := e.getAppNumArgs
   if nargs == 1 then
@@ -563,12 +572,14 @@ def isDefEqForall (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
       isDefEqForall tBody sBody (subst.push default)
   | t, s => isDefEq (t.instantiateRev subst) (s.instantiateRev subst)
 
-/-- Checks that `t` and `s` are definitionally equal if:
-- they are α-equivalent
-- they have matching head constructors and are not (non-α-equivalent) projections or applications
-- they have previously been checked for definitional equality
+/-- Decides definitional equality of `t` and `s` in the cases that can be settled without
+reduction, returning `.undef` to defer to the calling function otherwise.
 
-Otherwise, defers to the calling function. -/
+It returns `.true` if they are α-equivalent or have previously been checked for definitional
+equality, and otherwise decides two sorts by level equivalence and two literals by equality,
+returning `.false` where these disagree. Two lambdas or two for-alls are handed to
+`isDefEqLambda`/`isDefEqForall`, which may return either. All remaining cases — including two
+constants, two free variables, two applications and two projections — are deferred. -/
 def quickIsDefEq (t s : Expr) (useHash := false) : RecM LBool := do
   -- optimization for terms that are already α-equivalent or were previously checked
   if ← modifyGet fun (.mk a1 a2 a3 a4 a5 a6 a7 (eqvManager := m)) =>
@@ -613,9 +624,9 @@ def tryEtaExpansion (t s : Expr) : RecM Bool :=
 /-- Assuming `t` and `s` in WHNF, checks if they are defeq on account of `s` being defeq to the
 struct-η-expansion of `t`.
 
-Assuming that `t` has a struct type `S`, constructor `S.mk`, and projection functions `pᵢ : S → Tᵢ`,
-it struct-η-expands to `S.mk (p₁ t) ... (pₙ t)` (which it is definitionally equal to by the struct-η
-rule). -/
+Assuming that `t` has a non-recursive structure type `S` with constructor `S.mk` and projections
+`pᵢ`, it struct-η-expands to `S.mk (p₁ t) ... (pₙ t)` (which it is definitionally equal to by the
+struct-η rule). -/
 def tryEtaStructCore (t s : Expr) : RecM Bool := do
   let .const f _ := s.getAppFn | return false
   let env ← getEnv
@@ -632,8 +643,9 @@ def tryEtaStructCore (t s : Expr) : RecM Bool := do
 
 @[inherit_doc tryEtaStructCore]
 def tryEtaStruct (t s : Expr) : RecM Bool :=
-  -- FIXME(kernel) can return false if `t` and `s` are both constructor applications
-  -- (we have already called `isDefEqApp` on them, which returned false)
+  -- when `t` and `s` are both constructor applications, `isDefEqApp` has already compared their
+  -- arguments and returned false, and the projections in `tryEtaStructCore` reduce back to those
+  -- same arguments, so both calls below merely redo that work. The kernel has the same redundancy.
   tryEtaStructCore t s <||> tryEtaStructCore s t
 
 /-- Checks if applications `t` and `s` (should be WHNF) are defeq on account of their function heads
@@ -678,14 +690,14 @@ def tryUnfoldProjApp (e : Expr) : RecM (Option Expr) := do
   return if e' != e then e' else none
 
 /-- Performs a single step of δ-reduction on `tn`, `sn`, or both (according to optimizations)
-followed by weak-head normalization (without further δ-reduction). If the resulting terms have
-matching head constructors (excluding non-α-equivalent applications and projections), or are
-applications with the same defined constant function head and defeq args, returns whether `tn` and
-`sn` are defeq. Otherwise, a return value indicates to the calling `lazyDeltaReduction` that
+followed by weak-head normalization (without further δ-reduction). Returns `.bool` if the resulting
+terms are settled by `quickIsDefEq`, or if they are applications of the same defined constant with
+defeq args. Otherwise returns `.continue`, indicating to the calling `lazyDeltaReduction` that
 δ-reduction is to be continued.
 
-If δ-reduction+weak-head-normalization cannot be continued (i.e. we have a weak-head normal form
-with `cheapProj := true`), defers further defeq-checking to `isDefEq`. -/
+If neither side has a δ-reducible head, returns `.unknown` with the terms unchanged, leaving further
+defeq-checking to `isDefEqCore'`. Note that these are weak-head normal forms with respect to
+`cheapProj := true`, so a projection at the head may still be reducible. -/
 def lazyDeltaReductionStep (tn sn : Expr) : RecM ReductionStatus := do
   let env ← getEnv
   let delta e := do whnfCore (← unfoldDefinition e).get! (cheapProj := true)
@@ -697,7 +709,8 @@ def lazyDeltaReductionStep (tn sn : Expr) : RecM ReductionStatus := do
   match isDelta env tn, isDelta env sn with
   | none, none => return .unknown tn sn
   | some _, none =>
-    -- FIXME(kernel) hasn't `whnfCore` already been called on `sn`? so when would this case arise?
+    -- `sn` was normalized with `cheapProj := true`, so a projection at its head may not have been
+    -- reduced; `tryUnfoldProjApp` retries it with the struct argument fully normalized
     if let some sn' ← tryUnfoldProjApp sn then
       cont tn sn'
     else
@@ -732,9 +745,9 @@ def isNatSuccOf? : Expr → Option Expr
   | .app (.const ``Nat.succ _) e => return e
   | _ => none
 
-/-- If `t` and `s` are both successors of natural numbers `t'` and `s'`, either as literals or
-`Nat.succ` applications, checks that `t'` and `s'` are definitionally equal. Otherwise, defers to
-the calling function. -/
+/-- Returns `.true` if `t` and `s` are both zero, either as a literal or as `Nat.zero`. If they are
+both successors of natural numbers `t'` and `s'`, either as literals or `Nat.succ` applications,
+checks that `t'` and `s'` are definitionally equal. Otherwise, defers to the calling function. -/
 def isDefEqOffset (t s : Expr) : RecM LBool := do
   if isNatZero t && isNatZero s then
     return .true
@@ -742,12 +755,14 @@ def isDefEqOffset (t s : Expr) : RecM LBool := do
   | some t', some s' => toLBoolM <| isDefEqCore t' s'
   | _, _ => return .undef
 
-/-- Returns whether the `cheapProj := true` weak-head normal forms of `tn` and `sn` are defeq if:
-- they have matching head constructors (excluding non-α-equivalent applications and projections)
-- they're both natural number successors (as literals or `Nat.succ` applications)
+/-- Repeatedly δ-reduces the `cheapProj := true` weak-head normal forms `tn` and `sn` until the
+question is settled. Returns `.bool` if:
+- they are both zero or both natural number successors (as literals or `Nat.succ` applications)
 - one of them can be converted to a natural number/boolean literal
+- a `lazyDeltaReductionStep` settles them
 
-Otherwise, defers to the calling function with these normal forms. -/
+Otherwise returns `.unknown` with the reduced terms, deferring to the calling function. Throws
+`.deterministicTimeout` after `FuelConfig.lazyDelta` steps. -/
 def lazyDeltaReduction (tn sn : Expr) : RecM ReductionStatus := do
   loop tn sn (← readThe Context).fuel.lazyDelta
 where
@@ -770,9 +785,9 @@ where
     | .continue tn sn => loop tn sn fuel
     | r => return r
 
-/-- If `t` is a string literal and `s` is a string constructor application, checks that they are
-defeq after turning `t` into a constructor application. Otherwise, defers to the calling
-function. -/
+/-- If `t` is a string literal and `s` is a `String.ofList` application, checks that they are defeq
+after expanding `t` into a `String.ofList` application of an explicit character list. Otherwise,
+defers to the calling function. -/
 def tryStringLitExpansionCore (t s : Expr) : RecM LBool := do
   let .lit (.strVal st) := t | return .undef
   let .app sf _ := s | return .undef
@@ -860,7 +875,7 @@ def Methods.withFuel : Nat → Methods
       whnf := fun e => whnf' e (withFuel n)
       inferType := fun e i => inferType' e i (withFuel n) }
 
-/-- Runs `x` with a limit on the recursion depth. -/
+/-- Runs `x` with a limit on the recursion depth, taken from `FuelConfig.recDepth`. -/
 def RecM.run (x : RecM α) : M α := do x (Methods.withFuel (← readThe Context).fuel.recDepth)
 
 def RecM.runTermElab (x : RecM α) (safety := DefinitionSafety.safe) : Elab.Term.TermElabM α :=

--- a/Lean4Lean/TypeChecker.lean
+++ b/Lean4Lean/TypeChecker.lean
@@ -76,38 +76,29 @@ inductive ReductionStatus where
 
 namespace Inner
 
-/--
-Reduces `e` to its weak-head normal form.
--/
+/-- Reduces `e` to its weak-head normal form. -/
 def whnf (e : Expr) : RecM Expr := fun m => m.whnf e
 
 @[inline] def withLCtx [MonadWithReaderOf LocalContext m] (lctx : LocalContext) (x : m α) : m α :=
   withReader (fun _ => lctx) x
 
-/--
-Ensures that `e` is defeq to some `e' := .sort ..`, returning `e'`. If not,
-throws an error with `s` (the expression required be a sort).
--/
+/-- Ensures that `e` is defeq to some `e' := .sort ..`, returning `e'`. If not, throws an error with
+`s` (the expression required to be a sort). -/
 def ensureSortCore (e s : Expr) : RecM Expr := do
   if e.isSort then return e
   let e ← whnf e
   if e.isSort then return e
   throw <| .typeExpected (← getEnv) (← getLCtx) s
 
-/--
-Ensures that `e` is defeq to some `e' := .forallE ..`, returning `e'`. If not,
-throws an error with `s := f a` (the application requiring `f` to be of
-function type).
--/
+/-- Ensures that `e` is defeq to some `e' := .forallE ..`, returning `e'`. If not, throws an error
+with `s := f a` (the application requiring `f` to be of function type). -/
 def ensureForallCore (e s : Expr) : RecM Expr := do
   if e.isForall then return e
   let e ← whnf e
   if e.isForall then return e
   throw <| .funExpected (← getEnv) (← getLCtx) s
 
-/--
-Checks that `l` does not contain any level parameters not found in the context `tc`.
--/
+/-- Checks that `l` does not contain any level parameters not found in the context `tc`. -/
 def checkLevel (tc : Context) (l : Level) : Except Exception Unit := do
   if let some n2 := l.getUndefParam tc.lparams then
     throw <| .other s!"invalid reference to undefined universe level parameter '{n2}'"
@@ -117,9 +108,7 @@ def inferFVar (tc : Context) (name : FVarId) : Except Exception Expr := do
     return decl.type
   throw <| .other "unknown free variable"
 
-/--
-Infers the type of `.const e ls`.
--/
+/-- Infers the type of `.const name ls`. -/
 def inferConstant (tc : Context) (name : Name) (ls : List Level) (inferOnly : Bool) :
     Except Exception Expr := do
   let e := Expr.const name ls
@@ -139,17 +128,13 @@ def inferConstant (tc : Context) (name : Name) (ls : List Level) (inferOnly : Bo
       checkLevel tc l
   return info.instantiateTypeLevelParams ls
 
-/--
-Infers the type of expression `e`. If `inferOnly := false`, this function will
-throw an error if and only if `e` is not typeable according to Lean's
-algorithmic typing judgment. Setting `inferOnly := true` optimizes to avoid
-unnecessary checks in the case that `e` is already known to be well-typed.
--/
+/-- Infers the type of expression `e`. If `inferOnly := false`, this function will throw an error
+if and only if `e` is not typeable according to Lean's algorithmic typing judgment. Setting
+`inferOnly := true` optimizes to avoid unnecessary checks in the case that `e` is already known to
+be well-typed. -/
 def inferType (e : Expr) (inferOnly := true) : RecM Expr := fun m => m.inferType e inferOnly
 
-/--
-Infers the type of lambda expression `e`.
--/
+/-- Infers the type of lambda expression `e`. -/
 def inferLambda (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
   loop fvars : Expr → RecM Expr
   | .lam name dom body bi => do
@@ -164,9 +149,7 @@ def inferLambda (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
     let r := r.cheapBetaReduce
     return (← getLCtx).mkForall fvars r
 
-/--
-Infers the type of for-all expression `e`.
--/
+/-- Infers the type of for-all expression `e`. -/
 def inferForall (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] #[] e where
   loop fvars us : Expr → RecM Expr
   | .forallE name dom body bi => do
@@ -180,17 +163,14 @@ def inferForall (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] #[] e wher
     let s ← ensureSortCore r e
     return .sort <| us.foldr mkLevelIMax' s.sortLevel!
 
-/--
-Returns whether `t` and `s` are definitionally equal according to Lean's
-algorithmic definitional equality judgment.
+/-- Returns whether `t` and `s` are definitionally equal according to Lean's algorithmic
+definitional equality judgment.
 
-NOTE: This function does not do any typechecking of its own on `t` and `s`.
-So, when this is used as part of a typechecking routine, it is expected that
-they are already well-typed (that is, that `check t` and `check s`
-did not/would not throw an error). This ensures in particular that any calls to
-`inferType e (inferOnly := false)` on subterms `e` would not fail, so we know
-that `e` types as the return value of `inferType e (inferOnly := true)`.
--/
+NOTE: This function does not do any typechecking of its own on `t` and `s`. So, when this is used as
+part of a typechecking routine, it is expected that they are already well-typed (that is, that
+`check t` and `check s` did not/would not throw an error). This ensures in particular that any calls
+to `inferType e (inferOnly := false)` on subterms `e` would not fail, so we know that `e` types as
+the return value of `inferType e (inferOnly := true)`. -/
 def isDefEqCore (t s : Expr) : RecM Bool := fun m => m.isDefEqCore t s
 
 @[inherit_doc isDefEqCore]
@@ -200,9 +180,7 @@ def isDefEq (t s : Expr) : RecM Bool := do
     modify fun st => { st with eqvManager := st.eqvManager.addEquiv t s }
   pure r
 
-/--
-Infers the type of application `e`, assuming that `e` is already well-typed.
--/
+/-- Infers the type of application `e`, assuming that `e` is already well-typed. -/
 def inferApp (e : Expr) : RecM Expr := do
   e.withApp fun f args =>
   let rec loop fType j i : RecM Expr :=
@@ -217,9 +195,7 @@ def inferApp (e : Expr) : RecM Expr := do
       return fType.instantiateRevRange j args.size args
   do loop (← inferType f) 0 0
 
-/--
-Infers the type of let-expression `e`.
--/
+/-- Infers the type of let-expression `e`. -/
 def inferLet (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
   loop fvars : Expr → RecM Expr
   | .letE name type val body _ => do
@@ -237,21 +213,17 @@ def inferLet (e : Expr) (inferOnly : Bool) : RecM Expr := loop #[] e where
     let r := r.cheapBetaReduce
     return (← getLCtx).mkForall fvars r
 
-/--
-Gets the universe level of the sort that `e`'s type is defeq to, failing if `e` is not a type.
--/
+/-- Gets the universe level of the sort that `e`'s type is defeq to, failing if `e` is not
+a type. -/
 def getSortLevel (e : Expr) : RecM Level := do
   let .sort u ← ensureSortCore (← inferType e) e | unreachable!
   return u
 
-/--
-Checks if `e` is a proposition, that is, if its type is a sort whose level normalizes to zero.
--/
+/-- Checks if `e` is a proposition, that is, if its type is a sort whose level normalizes to
+zero. -/
 def isProp (e : Expr) : RecM Bool := return (← getSortLevel e).isAlwaysZero
 
-/--
-Infers the type of structure projection `e`.
--/
+/-- Infers the type of structure projection `e`. -/
 def inferProj (typeName : Name) (idx : Nat) (struct structType : Expr) : RecM Expr := do
   let e := Expr.proj typeName idx struct
   let type ← whnf structType
@@ -331,19 +303,15 @@ def inferType' (e : Expr) (inferOnly : Bool) : RecM Expr := do
     { s with inferTypeC := s.inferTypeC.insert e r }
   return r
 
-/--
-Reduces `e` to its weak-head normal form, without unfolding definitions. This
-is a conservative version of `whnf` (which does unfold definitions), to be used
-for efficiency purposes.
+/-- Reduces `e` to its weak-head normal form, without unfolding definitions. This is a conservative
+version of `whnf` (which does unfold definitions), to be used for efficiency purposes.
 
-Setting `cheapRec` or `cheapProj` to `true` will cause the major premise/struct
-argument to be reduced "lazily" (using `whnfCore` rather than `whnf`) when
-reducing recursor applications/struct projections. This can be a useful
-optimization if we're checking the definitional equality of two recursor
-applications/struct projections of the same recursor/projection, where we
-might save some work by directly checking if the major premises/struct
-arguments are defeq (rather than eagerly applying a recursor rule/projection).
--/
+Setting `cheapRec` or `cheapProj` to `true` will cause the major premise/struct argument to be
+reduced "lazily" (using `whnfCore` rather than `whnf`) when reducing recursor applications/struct
+projections. This can be a useful optimization if we're checking the definitional equality of two
+recursor applications/struct projections of the same recursor/projection, where we might save some
+work by directly checking if the major premises/struct arguments are defeq (rather than eagerly
+applying a recursor rule/projection). -/
 def whnfCore (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
   fun m => m.whnfCore e cheapRec cheapProj
 
@@ -357,20 +325,15 @@ def reduceRecursor (e : Expr) (cheapRec := false) (cheapProj := false) : RecM (O
     return r
   return none
 
-/--
-Gets the weak-head normal form of the free variable `e`, which is the weak-head
-normal form of its definition if `e` is a let variable and itself if it is a
-lambda variable.
--/
+/-- Gets the weak-head normal form of the free variable `e`, which is the weak-head normal form of
+its definition if `e` is a let variable and itself if it is a lambda variable. -/
 def whnfFVar (e : Expr) (cheapRec cheapProj : Bool) : RecM Expr := do
   if let some (.ldecl (value := v) ..) := (← getLCtx).find? e.fvarId! then
     return ← whnfCore v cheapRec cheapProj
   return e
 
-/--
-Reduces a projection of `struct` at index `idx` (when `struct` is reducible to a
-constructor application).
--/
+/-- Reduces a projection of `struct` at index `idx` (when `struct` is reducible to a constructor
+application). -/
 def reduceProj (idx : Nat) (struct : Expr) (cheapRec cheapProj : Bool) : RecM (Option Expr) := do
   let mut c ← (if cheapProj then whnfCore struct cheapRec cheapProj else whnf struct)
   if let .lit (.strVal s) := c then
@@ -401,7 +364,9 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
   | .bvar .. | .sort .. | .mvar .. | .forallE .. | .const .. | .lam .. | .lit ..
   | .mdata .. => unreachable!
   | .fvar _ => return ← whnfFVar e cheapRec cheapProj
-  | .app .. => -- beta-reduce at the head as much as possible, apply any remaining `rargs` to the resulting expression, and re-run `whnfCore`
+  | .app .. =>
+    -- beta-reduce at the head as much as possible, apply any remaining `rargs`
+    -- to the resulting expression, and re-run `whnfCore`
     e.withAppRev fun f0 rargs => do
     -- the head may still be a let variable/binding, projection, or mdata-wrapped expression
     let f ← whnfCore f0 cheapRec cheapProj
@@ -423,7 +388,9 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
         pure e
     else
       let r := f.mkAppRevRange 0 rargs.size rargs
-      -- FIXME(kernel) guard with reduceRecursor (as in the previous case)? adding arguments can only result in further normalization if the head reduced to a partial recursor application
+      -- FIXME(kernel) guard with `reduceRecursor` (as in the previous case)? adding arguments
+      -- can only result in further normalization if the head reduced to a partial recursor
+      -- application
       save <|← whnfCore r cheapRec cheapProj
   | .letE _ _ val body _ =>
     save <|← whnfCore (body.instantiate1 val) cheapRec cheapProj
@@ -433,10 +400,8 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
     else
       save e
 
-/--
-Checks if `e` has a head constant that can be delta-reduced (that is, it is a
-theorem or definition), returning its `ConstantInfo` if so.
--/
+/-- Checks if `e` has a head constant that can be delta-reduced (that is, it is a theorem or
+definition), returning its `ConstantInfo` if so. -/
 def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
   if let .const c ls := e.getAppFn then
     if let some ci := env.find? c then
@@ -447,11 +412,8 @@ def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
 def instantiateDeltaValue (ci : ConstantInfo) (ls : List Level) : Expr :=
   ci.deltaValue?.get!.instantiateLevelParams ci.levelParams ls
 
-/--
-Checks if `e` has a head constant that can be delta-reduced (that is, it is a
-theorem or definition), returning its value (instantiated by level parameters)
-if so.
--/
+/-- Checks if `e` has a head constant that can be delta-reduced (that is, it is a theorem or
+definition), returning its value (instantiated by level parameters) if so. -/
 def unfoldDefinitionCore (e : Expr) : RecM (Option Expr) := do
   let .const _ ls := e | return none
   let env ← getEnv
@@ -462,10 +424,8 @@ def unfoldDefinitionCore (e : Expr) : RecM (Option Expr) := do
   modify fun s => { s with unfold := s.unfold.insert e r }
   return some r
 
-/--
-Unfolds the definition at the head of the application `e` (or `e` itself if it
-is not an application).
--/
+/-- Unfolds the definition at the head of the application `e` (or `e` itself if it is not an
+application). -/
 def unfoldDefinition (e : Expr) : RecM (Option Expr) := do
   if e.isApp then
     let f0 := e.getAppFn
@@ -485,12 +445,9 @@ def reduceNative (_env : Environment) (e : Expr) : Except Exception (Option Expr
 
 def rawNatLitExt? (e : Expr) : Option Nat := if e == .natZero then some 0 else e.rawNatLit?
 
-/--
-Reduces the application `f a b` to a Nat literal if `a` and `b` can be reduced
-to Nat literals.
+/-- Reduces the application `f a b` to a Nat literal if `a` and `b` can be reduced to Nat literals.
 
-Note: `f` should have an (efficient) external implementation.
--/
+Note: `f` should have an (efficient) external implementation. -/
 def reduceBinNatOp (f : Nat → Nat → Nat) (a b : Expr) : RecM (Option Expr) := do
   let some v1 := rawNatLitExt? (← whnf a) | return none
   let some v2 := rawNatLitExt? (← whnf b) | return none
@@ -504,23 +461,18 @@ def reducePow (a b : Expr) : RecM (Option Expr) := do
   if v2 > reducePowMaxExp then return none
   return some <| .lit <| .natVal <| Nat.pow v1 v2
 
-/--
-Reduces the application `f a b` to a boolean expression if `a` and `b` can be
-reduced to Nat literals.
+/-- Reduces the application `f a b` to a boolean expression if `a` and `b` can be reduced to Nat
+literals.
 
-Note: `f` should have an (efficient) external implementation.
--/
+Note: `f` should have an (efficient) external implementation. -/
 def reduceBinNatPred (f : Nat → Nat → Bool) (a b : Expr) : RecM (Option Expr) := do
   let some v1 := rawNatLitExt? (← whnf a) | return none
   let some v2 := rawNatLitExt? (← whnf b) | return none
   return toExpr <| f v1 v2
 
-/--
-Reduces `e` to a natural number literal if possible, where binary operations
-and predicates may be applied (provided they have an external implementation).
-These include: `Nat.add`, `Nat.sub`, `Nat.mul`, `Nat.pow`, `Nat.gcd`,
-`Nat.mod`, `Nat.div`, `Nat.beq`, `Nat.ble`.
--/
+/-- Reduces `e` to a natural number literal if possible, where binary operations and predicates may
+be applied (provided they have an external implementation). These include: `Nat.add`, `Nat.sub`,
+`Nat.mul`, `Nat.pow`, `Nat.gcd`, `Nat.mod`, `Nat.div`, `Nat.beq`, `Nat.ble`. -/
 def reduceNat (e : Expr) : RecM (Option Expr) := do
   let nargs := e.getAppNumArgs
   if nargs == 1 then
@@ -573,12 +525,9 @@ def whnf' (e : Expr) : RecM Expr := do
   modify fun s => { s with whnfCache := s.whnfCache.insert e r }
   return r
 
-/--
-If `t` and `s` are lambda expressions, checks that their domains are defeq and
-recurses on the bodies, substituting in a new free variable for that binder
-(this substitution is delayed for efficiency purposes using the `subst`
-parameter). Otherwise, does a normal defeq check.
--/
+/-- If `t` and `s` are lambda expressions, checks that their domains are defeq and recurses on the
+bodies, substituting in a new free variable for that binder (this substitution is delayed for
+efficiency purposes using the `subst` parameter). Otherwise, does a normal defeq check. -/
 def isDefEqLambda (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
   match t, s with
   | .lam _ tDom tBody _, .lam name sDom sBody bi => do
@@ -595,12 +544,9 @@ def isDefEqLambda (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
       isDefEqLambda tBody sBody (subst.push default)
   | t, s => isDefEq (t.instantiateRev subst) (s.instantiateRev subst)
 
-/--
-If `t` and `s` are for-all expressions, checks that their domains are defeq and
-recurses on the bodies, substituting in a new free variable for that binder
-(this substitution is delayed for efficiency purposes using the `subst`
-parameter). Otherwise, does a normal defeq check.
--/
+/-- If `t` and `s` are for-all expressions, checks that their domains are defeq and recurses on the
+bodies, substituting in a new free variable for that binder (this substitution is delayed for
+efficiency purposes using the `subst` parameter). Otherwise, does a normal defeq check. -/
 def isDefEqForall (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
   match t, s with
   | .forallE _ tDom tBody _, .forallE name sDom sBody bi => do
@@ -617,14 +563,12 @@ def isDefEqForall (t s : Expr) (subst : Array Expr := #[]) : RecM Bool :=
       isDefEqForall tBody sBody (subst.push default)
   | t, s => isDefEq (t.instantiateRev subst) (s.instantiateRev subst)
 
-/--
-Checks that `t` and `s` are definitionally equal if:
+/-- Checks that `t` and `s` are definitionally equal if:
 - they are α-equivalent
-- they have matching head constructors and are not (non-α-equivalent)
-  projections or applications
+- they have matching head constructors and are not (non-α-equivalent) projections or applications
 - they have previously been checked for definitional equality
-Otherwise, defers to the calling function.
--/
+
+Otherwise, defers to the calling function. -/
 def quickIsDefEq (t s : Expr) (useHash := false) : RecM LBool := do
   -- optimization for terms that are already α-equivalent or were previously checked
   if ← modifyGet fun (.mk a1 a2 a3 a4 a5 a6 a7 (eqvManager := m)) =>
@@ -640,11 +584,9 @@ def quickIsDefEq (t s : Expr) (useHash := false) : RecM LBool := do
   | .lit a1, .lit a2 => pure (a1 == a2).toLBool
   | _, _ => return .undef
 
-/--
-Assuming that `t` and `s` have the same function heads, returns true if they
-are applications with definitionally equal arguments (in which case they are
-defeq), and false otherwise (deferring further defeq checking to caller).
--/
+/-- Assuming that `t` and `s` have the same function heads, returns true if they are applications
+with definitionally equal arguments (in which case they are defeq), and false otherwise (deferring
+further defeq checking to caller). -/
 def isDefEqArgs (t s : Expr) : RecM Bool := do
   match t, s with
   | .app tf ta, .app sf sa =>
@@ -653,13 +595,11 @@ def isDefEqArgs (t s : Expr) : RecM Bool := do
   | .app .., _ | _, .app .. => return false
   | _, _ => return true
 
-/--
-Assuming `t` and `s` are WHNF, checks if they are defeq on account of `t` being
-an η-expansion of `s`.
+/-- Assuming `t` and `s` are WHNF, checks if they are defeq on account of `t` being an η-expansion
+of `s`.
 
-Assuming that `s` has a function type `(x : A) -> B x`, it η-expands to
-`fun (x : A) => s x` (which it is definitionally equal to by the η rule).
--/
+Assuming that `s` has a function type `(x : A) → B x`, it η-expands to `fun (x : A) => s x`
+(which it is definitionally equal to by the η rule). -/
 def tryEtaExpansionCore (t s : Expr) : RecM Bool := do
   if t.isLambda && !s.isLambda then
     let .forallE name ty _ bi ← whnf (← inferType s) | return false
@@ -670,14 +610,12 @@ def tryEtaExpansionCore (t s : Expr) : RecM Bool := do
 def tryEtaExpansion (t s : Expr) : RecM Bool :=
   tryEtaExpansionCore t s <||> tryEtaExpansionCore s t
 
-/--
-Assuming `t` and `s` in WHNF, checks if they are defeq on account of `s` being
-defeq to the struct-η-expansion of `t`.
+/-- Assuming `t` and `s` in WHNF, checks if they are defeq on account of `s` being defeq to the
+struct-η-expansion of `t`.
 
-Assuming that `t` has a struct type `S`, constructor `S.mk`, and projection
-functions `pᵢ : S → Tᵢ`, it struct-η-expands to `S.mk (p₁ t) ... (pₙ t)` (which
-it is definitionally equal to by the struct-η rule).
--/
+Assuming that `t` has a struct type `S`, constructor `S.mk`, and projection functions `pᵢ : S → Tᵢ`,
+it struct-η-expands to `S.mk (p₁ t) ... (pₙ t)` (which it is definitionally equal to by the struct-η
+rule). -/
 def tryEtaStructCore (t s : Expr) : RecM Bool := do
   let .const f _ := s.getAppFn | return false
   let env ← getEnv
@@ -687,8 +625,8 @@ def tryEtaStructCore (t s : Expr) : RecM Bool := do
   unless ← isDefEq (← inferType t) (← inferType s) do return false
   let args := s.getAppArgs
   for h : i in [fInfo.numParams:args.size] do
-    -- since `t` is in WHNF, and assuming it is not a constructor application, this projection cannot reduce
-    -- (so we are directly checking if `s` is defeq to the struct-η-expansion of `t`)
+    -- since `t` is in WHNF, and assuming it is not a constructor application, this projection
+    -- cannot reduce (so we are directly checking if `s` is defeq to the struct-η-expansion of `t`)
     unless ← isDefEq (.proj fInfo.induct (i - fInfo.numParams) t) args[i] do return false
   return true
 
@@ -698,10 +636,8 @@ def tryEtaStruct (t s : Expr) : RecM Bool :=
   -- (we have already called `isDefEqApp` on them, which returned false)
   tryEtaStructCore t s <||> tryEtaStructCore s t
 
-/--
-Checks if applications `t` and `s` (should be WHNF) are defeq on account of
-their function heads and arguments being defeq.
--/
+/-- Checks if applications `t` and `s` (should be WHNF) are defeq on account of their function heads
+and arguments being defeq. -/
 def isDefEqApp (t s : Expr) : RecM Bool := do
   unless t.isApp && s.isApp do return false
   t.withApp fun tf tArgs =>
@@ -716,10 +652,8 @@ def isDefEqApp (t s : Expr) : RecM Bool := do
     loop 0
   else return false
 
-/--
-Checks if `t` and `s` are definitionally equivalent according to proof irrelevance
-(that is, they are proofs of the same proposition).
--/
+/-- Checks if `t` and `s` are definitionally equivalent according to proof irrelevance (that is,
+they are proofs of the same proposition). -/
 def isDefEqProofIrrel (t s : Expr) : RecM LBool := do
   let tType ← inferType t
   if !(← isProp tType) then return .undef
@@ -743,19 +677,15 @@ def tryUnfoldProjApp (e : Expr) : RecM (Option Expr) := do
   let e' ← whnfCore e
   return if e' != e then e' else none
 
-/--
-Performs a single step of δ-reduction on `tn`, `sn`, or both (according to
-optimizations) followed by weak-head normalization (without further
-δ-reduction). If the resulting terms have matching head constructors (excluding
-non-α-equivalent applications and projections), or are applications with the
-same defined constant function head and defeq args, returns whether `tn` and
-`sn` are defeq. Otherwise, a return value indicates to the calling
-`lazyDeltaReduction` that δ-reduction is to be continued.
+/-- Performs a single step of δ-reduction on `tn`, `sn`, or both (according to optimizations)
+followed by weak-head normalization (without further δ-reduction). If the resulting terms have
+matching head constructors (excluding non-α-equivalent applications and projections), or are
+applications with the same defined constant function head and defeq args, returns whether `tn` and
+`sn` are defeq. Otherwise, a return value indicates to the calling `lazyDeltaReduction` that
+δ-reduction is to be continued.
 
-If δ-reduction+weak-head-normalization cannot be continued (i.e. we have a
-weak-head normal form (with cheapProj := true)), defers further defeq-checking
-to `isDefEq`.
--/
+If δ-reduction+weak-head-normalization cannot be continued (i.e. we have a weak-head normal form
+with `cheapProj := true`), defers further defeq-checking to `isDefEq`. -/
 def lazyDeltaReductionStep (tn sn : Expr) : RecM ReductionStatus := do
   let env ← getEnv
   let delta e := do whnfCore (← unfoldDefinition e).get! (cheapProj := true)
@@ -767,7 +697,7 @@ def lazyDeltaReductionStep (tn sn : Expr) : RecM ReductionStatus := do
   match isDelta env tn, isDelta env sn with
   | none, none => return .unknown tn sn
   | some _, none =>
-    -- FIXME(kernel) hasn't whnfCore already been called on sn? so when would this case arise?
+    -- FIXME(kernel) hasn't `whnfCore` already been called on `sn`? so when would this case arise?
     if let some sn' ← tryUnfoldProjApp sn then
       cont tn sn'
     else
@@ -802,11 +732,9 @@ def isNatSuccOf? : Expr → Option Expr
   | .app (.const ``Nat.succ _) e => return e
   | _ => none
 
-/--
-If `t` and `s` are both successors of natural numbers `t'` and `s'`, either as
-literals or `Nat.succ` applications, checks that `t'` and `s'` are
-definitionally equal. Otherwise, defers to the calling function.
--/
+/-- If `t` and `s` are both successors of natural numbers `t'` and `s'`, either as literals or
+`Nat.succ` applications, checks that `t'` and `s'` are definitionally equal. Otherwise, defers to
+the calling function. -/
 def isDefEqOffset (t s : Expr) : RecM LBool := do
   if isNatZero t && isNatZero s then
     return .true
@@ -814,15 +742,12 @@ def isDefEqOffset (t s : Expr) : RecM LBool := do
   | some t', some s' => toLBoolM <| isDefEqCore t' s'
   | _, _ => return .undef
 
-/--
-Returns whether the `cheapProj := true` weak-head normal forms of `tn` and
-`sn` are defeq if:
-- they have matching head constructors (excluding non-α-equivalent applications
-  and projections)
+/-- Returns whether the `cheapProj := true` weak-head normal forms of `tn` and `sn` are defeq if:
+- they have matching head constructors (excluding non-α-equivalent applications and projections)
 - they're both natural number successors (as literals or `Nat.succ` applications)
-- one of them can be converted to a natural number/boolean literal.
-Otherwise, defers to the calling function with these normal forms.
--/
+- one of them can be converted to a natural number/boolean literal
+
+Otherwise, defers to the calling function with these normal forms. -/
 def lazyDeltaReduction (tn sn : Expr) : RecM ReductionStatus := do
   loop tn sn (← readThe Context).fuel.lazyDelta
 where
@@ -845,11 +770,9 @@ where
     | .continue tn sn => loop tn sn fuel
     | r => return r
 
-/--
-If `t` is a string literal and `s` is a string constructor application,
-checks that they are defeq after turning `t` into a constructor application.
-Otherwise, defers to the calling function.
--/
+/-- If `t` is a string literal and `s` is a string constructor application, checks that they are
+defeq after turning `t` into a constructor application. Otherwise, defers to the calling
+function. -/
 def tryStringLitExpansionCore (t s : Expr) : RecM LBool := do
   let .lit (.strVal st) := t | return .undef
   let .app sf _ := s | return .undef
@@ -862,10 +785,8 @@ def tryStringLitExpansion (t s : Expr) : RecM LBool := do
   | .undef => tryStringLitExpansionCore s t
   | r => return r
 
-/--
-Checks if `t` and `s` are defeq on account of both being of a unit type (a type
-with one constructor without any fields or indices).
--/
+/-- Checks if `t` and `s` are defeq on account of both being of a unit type (a type with one
+constructor without any fields or indices). -/
 def isDefEqUnitLike (t s : Expr) : RecM Bool := do
   let tType ← whnf (← inferType t)
   let .const I _ := tType.getAppFn | return false
@@ -903,11 +824,11 @@ def isDefEqCore' (t s : Expr) : RecM Bool := do
     if tf == sf && Level.isEquivList tl sl then return true
   | .fvar tv, .fvar sv => if tv == sv then return true
   | .proj _ ti te, .proj _ si se =>
-    -- optimized by the previous reduction functions using `cheapProj = true`
+    -- optimized by the previous reduction functions using `cheapProj := true`
     if ti == si then if ← isDefEq te se then return true
   | _, _ => pure ()
 
-  -- the previous reduction functions used `cheapProj = true`, so we may not have a complete WHNF
+  -- the previous reduction functions used `cheapProj := true`, so we may not have a complete WHNF
   let tnn ← whnfCore tn
   let snn ← whnfCore sn
   if !(ptrEqExpr tnn tn && ptrEqExpr snn sn) then
@@ -939,9 +860,7 @@ def Methods.withFuel : Nat → Methods
       whnf := fun e => whnf' e (withFuel n)
       inferType := fun e i => inferType' e i (withFuel n) }
 
-/--
-Runs `x` with a limit on the recursion depth.
--/
+/-- Runs `x` with a limit on the recursion depth. -/
 def RecM.run (x : RecM α) : M α := do x (Methods.withFuel (← readThe Context).fuel.recDepth)
 
 def RecM.runTermElab (x : RecM α) (safety := DefinitionSafety.safe) : Elab.Term.TermElabM α :=
@@ -956,19 +875,15 @@ def whnfCore (e : Expr) : M Expr := (Inner.whnfCore e).run
 
 def unfoldDefinition (e : Expr) : M Expr := return (← (Inner.unfoldDefinition e).run).getD e
 
-/--
-Infers the type of expression `e`. Note that this uses the optimization
-`inferOnly := true`, and so should only be used for the purpose of type
-inference on terms that are known to be well-typed. To typecheck terms for the
-first time, use `checkType`.
--/
+/-- Infers the type of expression `e`. Note that this uses the optimization `inferOnly := true`, and
+so should only be used for the purpose of type inference on terms that are known to be well-typed.
+To typecheck terms for the first time, use `checkType`. -/
 def inferType (e : Expr) : M Expr := (Inner.inferType e).run
 
-/--
-Infers the type of expression `e` and checks that `e` is well-typed according to Lean's typing judgment.
+/-- Infers the type of expression `e` and checks that `e` is well-typed according to Lean's typing
+judgment.
 
-Use `inferType` to infer type alone.
--/
+Use `inferType` to infer type alone. -/
 def checkType (e : Expr) : M Expr := (Inner.inferType e (inferOnly := false)).run
 
 @[inherit_doc isDefEqCore]
@@ -983,9 +898,7 @@ def ensureSort (t : Expr) (s := t) : M Expr := (ensureSortCore t s).run
 @[inherit_doc ensureForallCore]
 def ensureForall (t : Expr) (s := t) : M Expr := (ensureForallCore t s).run
 
-/--
-Ensures that `e` is a type/proposition. If it is not, throws an error.
--/
+/-- Ensures that `e` is a type/proposition. If it is not, throws an error. -/
 def ensureType (e : Expr) : M Expr := do ensureSort (← inferType e) e
 
 def etaExpand (e : Expr) : M Expr :=


### PR DESCRIPTION
Squash merge of PR #2 by rish987.
Reference: https://github.com/digama0/lean4lean/pull/2

Adds documentation for defeq and type-inference related functions to improve codebase understandability.