### PR TITLE
Fix constDF case in Stratified induction

### DIFF
--- a/Lean4Lean/Experimental/Stratified.lean
+++ b/Lean4Lean/Experimental/Stratified.lean
@@ -86,9 +86,9 @@ theorem IsDefEq.induction1
   | bvar h => exact ⟨.bvar h, .bvar h, .refl (hty (.bvar h))⟩
   | symm _ ih => exact ⟨ih.2.1, ih.1, .symm ih.2.2⟩
   | trans _ _ ih1 ih2 => exact ⟨ih1.1, ih2.2.1, .trans ih1.2.2 ih2.2.2⟩
-  | @constDF _ _ ls₁ ls₂ u _ h1 h2 h3 h4 h5 =>
+  | @constDF _ _ ls₁ ls₂ u _ h1 h2 h3 h4 h5 hwf hstrong0 hstrong ih0 ih =>
     exact ⟨.const h1 h2 h4,
-      .defeq (u := u.inst ls₁) sorry <| .const h1 h3 (h5.length_eq.symm.trans h4),
+      .defeq (hdf <| .symm ih.2.2) <| .const h1 h3 (h5.length_eq.symm.trans h4),
       .constDF h1 h2 h3 h4 h5⟩
   | @sortDF l l' _ h1 h2 h3 =>
     refine ⟨.sort h1, ?_, .sortDF h1 h2 h3⟩


### PR DESCRIPTION
## Summary

This removes one `sorry` in `Lean4Lean/Experimental/Stratified.lean`, in the `constDF` case of `IsDefEq.induction1`.

This is the typed/stratified analogue of #14. The proof binds the recursive induction hypotheses explicitly in the `constDF` case pattern and uses the Γ-level induction hypothesis in reverse through `hdf`.

A first attempt with an explicit universe argument failed because it over-constrained the type index. Letting Lean infer the `.defeq` universe argument resolves the index.

## Verification

Checked locally:

    lake build Lean4Lean.Experimental.Stratified
    lake build

Both passed.

Note: the repository still contains unrelated existing `sorry`s in other files; this PR only removes the target `sorry` in `Stratified.lean`.
