### PR TITLE
Bump Lean toolchain to v4.30.0

### DIFF
--- a/Lean4Lean/Declaration.lean
+++ b/Lean4Lean/Declaration.lean
@@ -2,6 +2,20 @@ import Lean.Declaration
 
 
 namespace Lean
+
+/--
+The value of a constant for the purpose of delta reduction: definitions and theorems have one,
+opaques do not. This mirrors the C++ `constant_info::has_value()`/`get_value()` pair.
+
+This is deliberately *not* `ConstantInfo.value?`, whose meaning changed in lean4#12973: it now
+excludes theorems, but `constant_info::has_value()` was left untouched by that PR, so the kernel
+still delta-unfolds theorems (`type_checker::is_delta` is its only consumer in `src/kernel`).
+-/
+def ConstantInfo.deltaValue? : ConstantInfo → Option Expr
+  | .defnInfo {value, ..} => some value
+  | .thmInfo {value, ..} => some value
+  | _ => none
+
 namespace ReducibilityHints
 
 def lt' : ReducibilityHints → ReducibilityHints → Bool -- lean4#2750

--- a/Lean4Lean/Environment.lean
+++ b/Lean4Lean/Environment.lean
@@ -53,9 +53,9 @@ def addTheorem (env : Environment) (v : TheoremVal) (check := true) (fuel : Fuel
   if check then
     -- TODO(Leo): we must add support for handling tasks here
     M.run env (safety := .safe) (lctx := {}) (lparams := v.levelParams) (fuel := fuel) do
+      checkConstantVal env v.toConstantVal
       if !(← isProp v.type) then
         throw <| .thmTypeIsNotProp env v.name v.type
-      checkConstantVal env v.toConstantVal
       let valType ← TypeChecker.checkType v.value
       if !(← isDefEq valType v.type) then
         throw <| .declTypeMismatch env (.thmDecl v) valType

--- a/Lean4Lean/Environment/Basic.lean
+++ b/Lean4Lean/Environment/Basic.lean
@@ -43,9 +43,10 @@ def primitives : NameSet := .ofList [
 /--
 Returns true iff `constName` is a non-recursive inductive datatype that has only one constructor and no indices.
 
-Such types have special kernel support. This must be in sync with `is_structure_like`.
+Such types have special kernel support (e.g. the eta rule).
+This must be in sync with `is_non_rec_structure()`.
 -/
-def isStructureLike (env : Environment) (constName : Name) : Bool :=
+def isNonRecStructure (env : Environment) (constName : Name) : Bool :=
   match env.find? constName with
   | some (.inductInfo { isRec := false, ctors := [_], numIndices := 0, .. }) => true
   | _ => false

--- a/Lean4Lean/Inductive/Reduce.lean
+++ b/Lean4Lean/Inductive/Reduce.lean
@@ -44,7 +44,7 @@ def expandEtaStruct (eType e : Expr) : Expr :=
   pure result
 
 def toCtorWhenStruct (inductName : Name) (e : Expr) : m Expr := do
-  if !env.isStructureLike inductName || (e.isConstructorApp?' env).isSome then
+  if !env.isNonRecStructure inductName || (e.isConstructorApp?' env).isSome then
     return e
   let eType ← whnf (← inferType e)
   if !eType.getAppFn.isConstOf inductName then return e

--- a/Lean4Lean/Tests.lean
+++ b/Lean4Lean/Tests.lean
@@ -1,0 +1,1 @@
+import Lean4Lean.Tests.Toolchain

--- a/Lean4Lean/Tests/Toolchain.lean
+++ b/Lean4Lean/Tests/Toolchain.lean
@@ -4,7 +4,7 @@ namespace Lean4Lean.Tests.Toolchain
 
 open Lean Lean4Lean TypeChecker TypeChecker.Inner
 
-theorem theoremOpacity : True := trivial
+theorem theoremDelta : True := trivial
 
 theorem proofOnlyDependency : True := trivial
 theorem dependencyOnlyInProof : True := proofOnlyDependency
@@ -16,10 +16,18 @@ run_meta
   let env ← getEnv
   let kenv := env.toKernelEnv
 
-  let some thmInfo := kenv.find? ``theoremOpacity
-    | throwError "theorem-opacity test declaration is missing"
+  let some thmInfo := kenv.find? ``theoremDelta
+    | throwError "theorem-delta test declaration is missing"
+  -- lean4#12973 flipped `ConstantInfo.hasValue` for theorems, but left
+  -- `constant_info::has_value()` -- the predicate `type_checker::is_delta` consults --
+  -- alone, so the kernel still delta-unfolds theorems. `isDelta` must follow the kernel,
+  -- not `hasValue`.
   unless !thmInfo.hasValue do
-    throwError "theorem values must not be delta-reducible"
+    throwError "expected `ConstantInfo.hasValue` to exclude theorems as of lean4#12973"
+  unless thmInfo.deltaValue?.isSome do
+    throwError "theorem values must remain delta-reducible"
+  unless (isDelta kenv (.const ``theoremDelta [])).isSome do
+    throwError "isDelta rejected a theorem, diverging from `type_checker::is_delta`"
 
   unless (isDelta kenv (.const ``Nat.add [.zero])).isNone do
     throwError "isDelta accepted an invalid universe arity"

--- a/Lean4Lean/Tests/Toolchain.lean
+++ b/Lean4Lean/Tests/Toolchain.lean
@@ -1,0 +1,39 @@
+import Main
+
+namespace Lean4Lean.Tests.Toolchain
+
+open Lean Lean4Lean TypeChecker TypeChecker.Inner
+
+theorem theoremOpacity : True := trivial
+
+theorem proofOnlyDependency : True := trivial
+theorem dependencyOnlyInProof : True := proofOnlyDependency
+
+def stringProof (_ : String) : True := trivial
+theorem stringOnlyInProof : True := stringProof "audit"
+
+run_meta
+  let env ← getEnv
+  let kenv := env.toKernelEnv
+
+  let some thmInfo := kenv.find? ``theoremOpacity
+    | throwError "theorem-opacity test declaration is missing"
+  unless !thmInfo.hasValue do
+    throwError "theorem values must not be delta-reducible"
+
+  unless (isDelta kenv (.const ``Nat.add [.zero])).isNone do
+    throwError "isDelta accepted an invalid universe arity"
+  unless (isDelta kenv (.const ``Nat.add [])).isSome do
+    throwError "isDelta rejected a valid definition"
+
+  let some depInfo := env.find? ``dependencyOnlyInProof
+    | throwError "proof-dependency test declaration is missing"
+  unless depInfo.getUsedConstants.contains ``proofOnlyDependency do
+    throwError "theorem proof dependency was omitted during replay analysis"
+
+  let some strInfo := env.find? ``stringOnlyInProof
+    | throwError "string-literal test declaration is missing"
+  unless strInfo.hasStrLit do
+    throwError "string literal in theorem proof was omitted during replay analysis"
+
+end Lean4Lean.Tests.Toolchain

--- a/Lean4Lean/TypeChecker.lean
+++ b/Lean4Lean/TypeChecker.lean
@@ -345,9 +345,9 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
       save e
 
 def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
-  if let .const c _ := e.getAppFn then
+  if let .const c ls := e.getAppFn then
     if let some ci := env.find? c then
-      if ci.hasValue then
+      if ci.hasValue && ls.length == ci.numLevelParams then
         return ci
   none
 
@@ -355,7 +355,6 @@ def unfoldDefinitionCore (e : Expr) : RecM (Option Expr) := do
   let .const _ ls := e | return none
   let env ← getEnv
   let some d := isDelta env e | return none
-  unless ls.length == d.numLevelParams do return none
   unless 0 < ls.length do return some (d.instantiateValueLevelParams! ls)
   if let some r := (← get).unfold[e]? then return some r
   let r := d.instantiateValueLevelParams! ls

--- a/Lean4Lean/TypeChecker.lean
+++ b/Lean4Lean/TypeChecker.lean
@@ -347,17 +347,20 @@ def whnfCore' (e : Expr) (cheapRec := false) (cheapProj := false) : RecM Expr :=
 def isDelta (env : Environment) (e : Expr) : Option ConstantInfo := do
   if let .const c ls := e.getAppFn then
     if let some ci := env.find? c then
-      if ci.hasValue && ls.length == ci.numLevelParams then
+      if ci.deltaValue?.isSome && ls.length == ci.numLevelParams then
         return ci
   none
+
+def instantiateDeltaValue (ci : ConstantInfo) (ls : List Level) : Expr :=
+  ci.deltaValue?.get!.instantiateLevelParams ci.levelParams ls
 
 def unfoldDefinitionCore (e : Expr) : RecM (Option Expr) := do
   let .const _ ls := e | return none
   let env ← getEnv
   let some d := isDelta env e | return none
-  unless 0 < ls.length do return some (d.instantiateValueLevelParams! ls)
+  unless 0 < ls.length do return some (instantiateDeltaValue d ls)
   if let some r := (← get).unfold[e]? then return some r
-  let r := d.instantiateValueLevelParams! ls
+  let r := instantiateDeltaValue d ls
   modify fun s => { s with unfold := s.unfold.insert e r }
   return some r
 
@@ -517,7 +520,7 @@ def tryEtaStructCore (t s : Expr) : RecM Bool := do
   let env ← getEnv
   let .ctorInfo fInfo ← env.get f | return false
   unless s.getAppNumArgs == fInfo.numParams + fInfo.numFields do return false
-  unless env.isStructureLike fInfo.induct do return false
+  unless env.isNonRecStructure fInfo.induct do return false
   unless ← isDefEq (← inferType t) (← inferType s) do return false
   let args := s.getAppArgs
   for h : i in [fInfo.numParams:args.size] do

--- a/Lean4Lean/Verify/Environment/Lemmas.lean
+++ b/Lean4Lean/Verify/Environment/Lemmas.lean
@@ -1,4 +1,5 @@
 import Lean4Lean.Std.SMap
+import Lean4Lean.Declaration
 import Lean4Lean.Verify.Environment.Basic
 
 namespace Lean4Lean
@@ -138,7 +139,7 @@ theorem TrEnv.find?_uniq (H : TrEnv safety env venv)
   H.aligned.find?_uniq (H.map_wf.find?'_eq_find? _ ▸ h) hs
 
 theorem TrEnv'.of_value (H : TrEnv' safety C Q venv) (h : C.find? name = some ci)
-    (hs : safety ≤ ci.safety) (hv : ci.value? = some v) :
+    (hs : safety ≤ ci.safety) (hv : ci.deltaValue? = some v) :
     TrExpr venv ci.levelParams [] v (.const ci.name (VLevel.params ci.levelParams.length)) := by
   have {C n ci'} (hC : C.WF) :
       (SMap.insert C n ci').find? name = some ci →
@@ -172,6 +173,6 @@ theorem TrEnv'.of_value (H : TrEnv' safety C Q venv) (h : C.find? name = some ci
   | induct _ h1 H ih => cases h1
 
 nonrec theorem TrEnv.of_value (H : TrEnv safety env venv) (h : env.find? name = some ci)
-    (hs : safety ≤ ci.safety) (hv : ci.value? = some v) :
+    (hs : safety ≤ ci.safety) (hv : ci.deltaValue? = some v) :
     TrExpr venv ci.levelParams [] v (.const ci.name (VLevel.params ci.levelParams.length)) :=
   H.of_value (by rwa [← H.map_wf.find?'_eq_find?]) hs hv

--- a/Lean4Lean/Verify/TypeChecker/Basic.lean
+++ b/Lean4Lean/Verify/TypeChecker/Basic.lean
@@ -239,7 +239,7 @@ theorem WHNFCache.WF.empty : WHNFCache.WF c s {} := fun _ => by simp
 
 def UnfoldCache.WF (c : VContext) (m : ExprMap Expr) : Prop :=
   ∀ ⦃e e' : Expr⦄, m[e]? = some e' → ∃ n ls ci, e = .const n ls ∧
-      c.env.find? n = some ci ∧ e' = ci.instantiateValueLevelParams! ls
+      c.env.find? n = some ci ∧ e' = Inner.instantiateDeltaValue ci ls
 
 class VState.WF (c : VContext) (s : VState) where
   trctx : c.TrLCtx
@@ -883,15 +883,15 @@ theorem whnfCore.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
   fun _ wf => wf.whnfCore he
 
 theorem isDelta_is_some : isDelta env e = some ci ↔
-    ∃ n, env.find? n = some ci ∧ (∃ v, ci.value? = some v) ∧
+    ∃ n, env.find? n = some ci ∧ (∃ v, ci.deltaValue? = some v) ∧
       ∃ ls, e.getAppFn = .const n ls ∧ ls.length = ci.numLevelParams := by
   simp only [isDelta]
   split <;> [split <;> [split; skip]; skip] <;>
-    simp_all [ConstantInfo.hasValue_eq, Option.isSome_iff_exists] <;> grind
+    simp_all [Option.isSome_iff_exists] <;> grind
 
 def UnfoldDefinition.WF (c : VContext) (e e₀ : Expr) (e' : VExpr) : Option Expr → Prop
   | some e₁ => c.FVarsBelow e e₁ ∧ c.TrExpr e₁ e'
-  | none => ∀ {{n ci v ls}}, c.env.find? n = some ci → ci.value? = some v →
+  | none => ∀ {{n ci v ls}}, c.env.find? n = some ci → ci.deltaValue? = some v →
     e₀ = .const n ls → ls.length = ci.numLevelParams → False
 
 theorem unfoldDefinitionCore.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
@@ -904,10 +904,10 @@ theorem unfoldDefinitionCore.WF {c : VContext} {s : VState} (he : c.TrExprS e e'
   rename_i n ls oci ci h1
   obtain ⟨_, h3, ⟨_, h4⟩, _, ⟨⟩, hlen⟩ := isDelta_is_some.1 h1
   have : UnfoldDefinition.WF c (.const n ls) (.const n ls) e'
-      (some (ci.instantiateValueLevelParams! ls)) := by
+      (some (instantiateDeltaValue ci ls)) := by
     let .const a1 a2 a3 := he
     have ⟨rfl, b1, b2, b3⟩ := c.trenv.find?_uniq h3 a1
-    simp [ConstantInfo.instantiateValueLevelParams!, ConstantInfo.value!_eq, h4]
+    simp [instantiateDeltaValue, h4]
     have c1 := c.trenv.of_value h3 b1 h4 |>.instL c.Ewf (by trivial) a2 (b2.trans a3.symm)
     have := c1.weakFV c.Ewf (.from_nil c.mlctx.noBV) c.Δwf
     rw [c1.wf.closedN c.Ewf trivial |>.liftN_eq (Nat.zero_le _)] at this

--- a/Lean4Lean/Verify/TypeChecker/Basic.lean
+++ b/Lean4Lean/Verify/TypeChecker/Basic.lean
@@ -883,11 +883,11 @@ theorem whnfCore.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
   fun _ wf => wf.whnfCore he
 
 theorem isDelta_is_some : isDelta env e = some ci ↔
-    ∃ n, env.find? n = some ci ∧ (∃ v, ci.value? = some v) ∧ ∃ ls, e.getAppFn = .const n ls := by
-  simp [isDelta]
+    ∃ n, env.find? n = some ci ∧ (∃ v, ci.value? = some v) ∧
+      ∃ ls, e.getAppFn = .const n ls ∧ ls.length = ci.numLevelParams := by
+  simp only [isDelta]
   split <;> [split <;> [split; skip]; skip] <;>
-    simp_all [ConstantInfo.hasValue_eq, Option.isSome_iff_exists] <;>
-    rintro rfl <;> assumption
+    simp_all [ConstantInfo.hasValue_eq, Option.isSome_iff_exists] <;> grind
 
 def UnfoldDefinition.WF (c : VContext) (e e₀ : Expr) (e' : VExpr) : Option Expr → Prop
   | some e₁ => c.FVarsBelow e e₁ ∧ c.TrExpr e₁ e'
@@ -899,12 +899,10 @@ theorem unfoldDefinitionCore.WF {c : VContext} {s : VState} (he : c.TrExprS e e'
   dsimp [unfoldDefinitionCore]
   split <;> [refine .getEnv ?_; (rename_i H; exact .pure fun _ _ _ _ _ _ h => nomatch H _ _ h)]
   split; rotate_left
-  · rename_i H; refine .pure ?_; rintro _ _ _ _ h1 h2 ⟨⟩
-    cases H _ (isDelta_is_some.2 ⟨_, h1, ⟨_, h2⟩, _, rfl⟩)
+  · rename_i H; refine .pure ?_; rintro _ _ _ _ h1 h2 ⟨⟩ hlen
+    cases H _ (isDelta_is_some.2 ⟨_, h1, ⟨_, h2⟩, _, rfl, hlen⟩)
   rename_i n ls oci ci h1
-  obtain ⟨_, h3, ⟨_, h4⟩, _, ⟨⟩⟩ := isDelta_is_some.1 h1
-  split <;> rename_i h2 <;> [refine .pureBind ?_; refine .pure ?_]; rotate_left
-  · simp at h2; rintro _ _ _ _ h1 _ ⟨⟩; cases h1 ▸ h3; exact h2
+  obtain ⟨_, h3, ⟨_, h4⟩, _, ⟨⟩, hlen⟩ := isDelta_is_some.1 h1
   have : UnfoldDefinition.WF c (.const n ls) (.const n ls) e'
       (some (ci.instantiateValueLevelParams! ls)) := by
     let .const a1 a2 a3 := he

--- a/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
+++ b/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
@@ -339,7 +339,7 @@ theorem lazyDeltaReductionStep.WF {c : VContext} {s : VState}
   refine .getEnv ?_; extract_lets delta cont F1 F2
   have hdelta {s e e' ci} (he : c.TrExprS e e') (H : isDelta c.env e = some ci) :
       (delta e).WF c s fun r _ => c.TrExpr r e' := by
-    let ⟨n, h1, ⟨_, h2⟩, ls, h3⟩ := isDelta_is_some.1 H
+    let ⟨n, h1, ⟨_, h2⟩, ls, h3, _⟩ := isDelta_is_some.1 H
     have ⟨_, stk⟩ := AppStack.build (e.mkAppList_getAppArgsList ▸ he)
     have .const a1 a2 a3 := h3 ▸ stk.tr
     have ⟨b1, b2, b3, b4⟩ := c.trenv.find?_uniq h1 a1
@@ -371,8 +371,8 @@ theorem lazyDeltaReductionStep.WF {c : VContext} {s : VState}
   split <;> [skip; exact cacheFailure.WF.lift.bind fun _ _ _ _ => hF1]
   rename_i h1 h2; simp at h1
   cases ptrEqConstantInfo_eq h1.1.1.2
-  have ⟨n₁, b1₁, ⟨_, b2₁⟩, ls₁, b3₁⟩ := isDelta_is_some.1 hd1
-  have ⟨n₂, b1₂, ⟨_, b2₂⟩, ls₂, b3₂⟩ := isDelta_is_some.1 hd2
+  have ⟨n₁, b1₁, ⟨_, b2₁⟩, ls₁, b3₁, _⟩ := isDelta_is_some.1 hd1
+  have ⟨n₂, b1₂, ⟨_, b2₂⟩, ls₂, b3₂, _⟩ := isDelta_is_some.1 hd2
   simp [b3₁, b3₂, Expr.constLevels!] at h2
   have ⟨_, stk₁⟩ := AppStack.build (e₁.mkAppList_getAppArgsList ▸ he₁)
   have ⟨_, stk₂⟩ := AppStack.build (e₂.mkAppList_getAppArgsList ▸ he₂)

--- a/Main.lean
+++ b/Main.lean
@@ -32,11 +32,12 @@ namespace ConstantInfo
 
 /-- Return all names appearing in the type or value of a `ConstantInfo`. -/
 def getUsedConstants (c : ConstantInfo) : NameSet :=
-  c.type.getUsedConstants' ++ match c.value? with
+  -- The kernel does not unfold theorem or opaque values, but replaying them still
+  -- requires their proof/body dependencies to be present in the environment.
+  c.type.getUsedConstants' ++ match c.value? (allowOpaque := true) with
   | some v => v.getUsedConstants'
   | none => match c with
     | .inductInfo val => .ofList val.ctors
-    | .opaqueInfo val => val.value.getUsedConstants'
     | .ctorInfo val => ({} : NameSet).insert val.name
     | .recInfo val => .ofList val.all
     | _ => {}
@@ -149,7 +150,7 @@ deriving instance BEq for RecursorVal
 def Lean.Expr.hasStrLit (e : Expr) : Bool := (e.find? isStringLit).isSome
 
 def Lean.ConstantInfo.hasStrLit (ci : ConstantInfo) : Bool :=
-  ci.type.hasStrLit || ci.value?.any (·.hasStrLit)
+  ci.type.hasStrLit || (ci.value? (allowOpaque := true)).any (·.hasStrLit)
 
 mutual
 /--

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,15 +1,16 @@
-{"version": "1.1.0",
+{"version": "1.2.0",
  "packagesDir": ".lake/packages",
  "packages":
  [{"url": "https://github.com/leanprover-community/batteries",
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "756e3321fd3b02a85ffda19fef789916223e578c",
+   "rev": "32dc18cde3684679f3c003de608743b57498c56f",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
-   "inputRev": "v4.29.0",
+   "inputRev": "v4.30.0",
    "inherited": false,
    "configFile": "lakefile.toml"}],
  "name": "lean4lean",
- "lakeDir": ".lake"}
+ "lakeDir": ".lake",
+ "fixedToolchain": false}

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -4,7 +4,7 @@ defaultTargets = ["Lean4Lean", "lean4lean", "Lean4Lean.Theory", "Lean4Lean.Verif
 [[require]]
 name = "batteries"
 git = "https://github.com/leanprover-community/batteries"
-rev = "v4.29.0"
+rev = "v4.30.0"
 
 [[lean_lib]]
 name = "Lean4Lean"

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -17,6 +17,12 @@ globs = ["Lean4Lean.Theory.*"]
 name = "Lean4Lean.Verify"
 globs = ["Lean4Lean.Verify.*"]
 
+# `Lean4Lean.Tests.Toolchain` imports `Main` (for the replay helpers). Declaring `Main` as a
+# library as well as the `lean4lean` exe root gives lake the dependency edge; without it the
+# test module only builds when `Main.olean` happens to already exist.
+[[lean_lib]]
+name = "Main"
+
 [[lean_lib]]
 name = "Lean4Lean.Tests"
 globs = ["Lean4Lean.Tests.*"]

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "lean4lean"
-defaultTargets = ["Lean4Lean", "lean4lean", "Lean4Lean.Theory", "Lean4Lean.Verify"]
+defaultTargets = ["Lean4Lean", "lean4lean", "Lean4Lean.Theory", "Lean4Lean.Verify", "Lean4Lean.Tests"]
 
 [[require]]
 name = "batteries"
@@ -16,6 +16,10 @@ globs = ["Lean4Lean.Theory.*"]
 [[lean_lib]]
 name = "Lean4Lean.Verify"
 globs = ["Lean4Lean.Verify.*"]
+
+[[lean_lib]]
+name = "Lean4Lean.Tests"
+globs = ["Lean4Lean.Tests.*"]
 
 [[lean_lib]]
 name = "Lean4Lean.Experimental"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.29.0
+leanprover/lean4:v4.30.0


### PR DESCRIPTION
Updates Lean and Batteries to v4.30.0.

### Lean kernel changes

The complete [`v4.29.0..v4.30.0`](https://github.com/leanprover/lean4/compare/v4.29.0...v4.30.0) `src/kernel` history consists of four upstream PRs:

- **Theorem value handling** ([lean4#12973](https://github.com/leanprover/lean4/pull/12973)). The PR made `declaration::has_value()` and Lean's `ConstantInfo.hasValue`/`value?` definitions-only by default, but the C++ type checker's separate `constant_info::has_value()` still includes definitions and theorems. Lean4lean therefore adds [`ConstantInfo.deltaValue?`](https://github.com/digama0/lean4lean/pull/20/files#diff-0c749d5ccc9c63cc35ebfb2f6cc02c32bc5ccf4195f0722dd3f3668de3a18dabR6) and uses it to mirror the kernel's actual delta-reduction predicate and value access in [`isDelta` and unfolding](https://github.com/digama0/lean4lean/pull/20/files#diff-9b967102e48820d1b3a5f6a7c950c7c3b5689e995d74639053c1eaee33e5b2b2R347). The verification layer follows the same predicate in [`isDelta_is_some`](https://github.com/digama0/lean4lean/pull/20/files#diff-2d303cae48e6de01697f972db62d6b06f3f26f3b89b0c2961c95ec816d7cfb0eR885). Replay separately requests hidden theorem and opaque bodies for [dependency discovery](https://github.com/digama0/lean4lean/pull/20/files#diff-dddcd969b084307f4de437eb6100cd8ee067fc31a79fa1f02884f339905ee72fR33) and [string-literal discovery](https://github.com/digama0/lean4lean/pull/20/files#diff-dddcd969b084307f4de437eb6100cd8ee067fc31a79fa1f02884f339905ee72fR150). [Regression checks](https://github.com/digama0/lean4lean/pull/20/files#diff-af2442a31054c78aa1fafbd451a7797201de929c3552d1310242367fb18ae35dR19) cover theorem delta-reduction and replay discovery.

- **Kernel robustness fixes** ([lean4#12817](https://github.com/leanprover/lean4/pull/12817)). The universe-arity check moves into [`isDelta`](https://github.com/digama0/lean4lean/pull/20/files#diff-9b967102e48820d1b3a5f6a7c950c7c3b5689e995d74639053c1eaee33e5b2b2R347), establishing that every successful delta candidate can be unfolded; the stronger invariant is reflected in [`isDelta_is_some`](https://github.com/digama0/lean4lean/pull/20/files#diff-2d303cae48e6de01697f972db62d6b06f3f26f3b89b0c2961c95ec816d7cfb0eR885) and its proof consumers. The theorem header is also checked before testing whether its type is a proposition, matching [`add_theorem`](https://github.com/digama0/lean4lean/pull/20/files#diff-b41ad8e59be7afd9e603ed079a6114cf5fd9aef9f76d0074cf5a2fb767204abfR51).

- **Rename “structure-like” to “non-recursive structure”** ([lean4#12749](https://github.com/leanprover/lean4/pull/12749)). This is terminology-only, with no kernel behavior change. Lean4lean mirrors the Lean and C++ rename in [its predicate](https://github.com/digama0/lean4lean/pull/20/files#diff-28194d189e73b5ac04ef0006cf275e22ea4bf0a235639808670e0fe8c9114dfcR43) and [reduction call sites](https://github.com/digama0/lean4lean/pull/20/files#diff-e085ed40edd11d9b8cc78b817140e19b7ffeba69204b8f2d49576a901a44d17cR46).

- **Move `instantiateMVars` from `src/kernel` to a fused implementation in `src/library`** ([lean4#12233](https://github.com/leanprover/lean4/pull/12233)). This is a metaprogramming performance change rather than a trusted type-checking rule, and lean4lean does not model the utility, so no corresponding source change is required.

:robot: prepared with assistance from Codex and Claude
