### PR TITLE
docs: correct theorem delta-reduction comments

### DIFF
--- a/Lean4Lean/Declaration.lean
+++ b/Lean4Lean/Declaration.lean
@@ -9,7 +9,8 @@ opaques do not. This mirrors the C++ `constant_info::has_value()`/`get_value()` 
 
 This is deliberately *not* `ConstantInfo.value?`, whose meaning changed in lean4#12973: it now
 excludes theorems, but `constant_info::has_value()` was left untouched by that PR, so the kernel
-still delta-unfolds theorems (`type_checker::is_delta` is its only consumer in `src/kernel`).
+still delta-unfolds theorems: `type_checker::is_delta` uses this predicate to select candidates,
+and `instantiate_value_lparams` uses it before reading their values.
 -/
 def ConstantInfo.deltaValue? : ConstantInfo → Option Expr
   | .defnInfo {value, ..} => some value

--- a/Main.lean
+++ b/Main.lean
@@ -32,8 +32,8 @@ namespace ConstantInfo
 
 /-- Return all names appearing in the type or value of a `ConstantInfo`. -/
 def getUsedConstants (c : ConstantInfo) : NameSet :=
-  -- The kernel does not unfold theorem or opaque values, but replaying them still
-  -- requires their proof/body dependencies to be present in the environment.
+  -- Replay needs dependencies from theorem proofs and opaque bodies even though
+  -- `ConstantInfo.value?` hides both by default.
   c.type.getUsedConstants' ++ match c.value? (allowOpaque := true) with
   | some v => v.getUsedConstants'
   | none => match c with


### PR DESCRIPTION
Corrects two comments following #20:

- names both C++ `constant_info::has_value()` call sites instead of calling `type_checker::is_delta` its only consumer;
- avoids incorrectly saying the kernel does not unfold theorems when explaining replay dependency discovery.

No code behavior changes.

Tested with `lake build` (143 jobs).

:robot: prepared with assistance from Codex
