### PR TITLE
feat: prove Level cached-flag correctness

### DIFF
--- a/Lean4Lean/Verify/Axioms.lean
+++ b/Lean4Lean/Verify/Axioms.lean
@@ -273,8 +273,14 @@ definition of `mkData` that preceded the `@[extern]` one. `panic!` evaluates to 
 logic, which drops both flag bits, and that is inconsistent with each of `hasParam_eq` and
 `hasMVar_eq` separately: `Level.succ` of a level of cached depth `2 ^ 24 - 1` would report
 `hasParam = false` however many `Level.param`s it contains, while `hasParam'` reports `true`.
-That was the soundness bug of leanprover/lean4#8554, fixed by leanprover/lean4#8559; the issue
-proposed saturating the depth, and the merged fix aborts instead.
+That was the soundness bug reported in leanprover/lean4#8554, fixed for `Level` by
+leanprover/lean4#8559 and for `Expr` by leanprover/lean4#8560, which moved the checks into C++
+so that they abort.
+
+Saturating here is not a claim that the kernel saturates; it does not, it aborts. It is a claim
+about which total function to pick for a branch on which the kernel returns nothing, and the
+only requirements on that pick are that it agree with the kernel everywhere the kernel returns,
+and that it keep the cached fields conservative.
 -/
 def mkData' (h : UInt64) (depth : Nat := 0) (hasMVar hasParam : Bool := false) : Level.Data :=
   h.toUInt32.toUInt64 +

--- a/Lean4Lean/Verify/Axioms.lean
+++ b/Lean4Lean/Verify/Axioms.lean
@@ -257,18 +257,24 @@ end
 axiom normalize_eq : normalize = Total.normalize
 
 /--
-The depth is clamped at `2 ^ 24 - 1` rather than guarded. The C++ implementation instead calls
-`lean_internal_panic` when the depth does not fit in 24 bits, which prints a message and calls
-`exit(1)`: that branch never returns a `Level.Data`, so `mkData` (an `opaque` declaration) is
-unconstrained there and no running program can observe which value we pick. Clamping keeps the
-`hasMVar` and `hasParam` bits, so `hasParam_eq` and `hasMVar_eq` hold unconditionally.
+A total specification of the `opaque` `mkData`. Wherever the C++ `lean_level_mk_data` returns,
+`mkData'` agrees with it.
 
-Writing the branch as `panic! "universe level depth is too big"`, as the pre-`extern` Lean
-definition did, evaluates to `0` in the logic and so drops both flag bits. That is jointly
-inconsistent with `hasParam_eq` and `hasMVar_eq`: `Level.succ` of a level of cached depth
-`2 ^ 24 - 1` would report `hasParam = false` however many `Level.param`s it contains, while
-`hasParam'` reports `true`. Building a level that deep aborts the real implementation, so
-nothing is lost by ruling the case out here.
+The depth is saturated at `2 ^ 24 - 1`. The C++ instead calls `lean_internal_panic` when the
+depth does not fit in 24 bits, which prints to stderr and calls `exit(1)`, so it returns no
+`Level.Data` at all on those inputs and pins down nothing there. Saturating keeps the `hasMVar`
+and `hasParam` bits, which is what makes `hasParam_eq` and `hasMVar_eq` hold unconditionally.
+This is not a claim that the implementation computes this value: `mkData_eq` is a specification
+chosen for the opaque constant, and results proved from it transfer to the implementation only
+for runs that do not abort.
+
+This branch used to read `panic! "universe level depth is too big"`, copied from the Lean
+definition of `mkData` that preceded the `@[extern]` one. `panic!` evaluates to `0` in the
+logic, which drops both flag bits, and that is inconsistent with each of `hasParam_eq` and
+`hasMVar_eq` separately: `Level.succ` of a level of cached depth `2 ^ 24 - 1` would report
+`hasParam = false` however many `Level.param`s it contains, while `hasParam'` reports `true`.
+That was the soundness bug of leanprover/lean4#8554, fixed by leanprover/lean4#8559; the issue
+proposed saturating the depth, and the merged fix aborts instead.
 -/
 def mkData' (h : UInt64) (depth : Nat := 0) (hasMVar hasParam : Bool := false) : Level.Data :=
   h.toUInt32.toUInt64 +

--- a/Lean4Lean/Verify/Axioms.lean
+++ b/Lean4Lean/Verify/Axioms.lean
@@ -256,37 +256,29 @@ end
 `Total.normalize` above is a total copy of it. -/
 axiom normalize_eq : normalize = Total.normalize
 
+/--
+The depth is clamped at `2 ^ 24 - 1` rather than guarded. The C++ implementation instead calls
+`lean_internal_panic` when the depth does not fit in 24 bits, which prints a message and calls
+`exit(1)`: that branch never returns a `Level.Data`, so `mkData` (an `opaque` declaration) is
+unconstrained there and no running program can observe which value we pick. Clamping keeps the
+`hasMVar` and `hasParam` bits, so `hasParam_eq` and `hasMVar_eq` hold unconditionally.
+
+Writing the branch as `panic! "universe level depth is too big"`, as the pre-`extern` Lean
+definition did, evaluates to `0` in the logic and so drops both flag bits. That is jointly
+inconsistent with `hasParam_eq` and `hasMVar_eq`: `Level.succ` of a level of cached depth
+`2 ^ 24 - 1` would report `hasParam = false` however many `Level.param`s it contains, while
+`hasParam'` reports `true`. Building a level that deep aborts the real implementation, so
+nothing is lost by ruling the case out here.
+-/
 def mkData' (h : UInt64) (depth : Nat := 0) (hasMVar hasParam : Bool := false) : Level.Data :=
-  if depth > Nat.pow 2 24 - 1 then panic! "universe level depth is too big"
-  else
-    h.toUInt32.toUInt64 +
-    hasMVar.toUInt64.shiftLeft 32 +
-    hasParam.toUInt64.shiftLeft 33 +
-    depth.toUInt64.shiftLeft 40
+  h.toUInt32.toUInt64 +
+  hasMVar.toUInt64.shiftLeft 32 +
+  hasParam.toUInt64.shiftLeft 33 +
+  (min depth (2 ^ 24 - 1)).toUInt64.shiftLeft 40
 
 /-- This exists only for the bit-twiddling proofs, it shouldn't appear
 in the main results, which use the functions below instead -/
 axiom mkData_eq : @mkData = @mkData'
-
-def hasParam' : Level → Bool
-  | .param .. => true
-  | .zero | .mvar .. => false
-  | .succ l => l.hasParam'
-  | .max l₁ l₂ | .imax l₁ l₂ => l₁.hasParam' || l₂.hasParam'
-
-/-- This was false prior to the fix of lean4#8554; it should now be provable
-using `mkData_eq` and friends, but this has not been done yet -/
-@[simp] axiom hasParam_eq (l : Level) : l.hasParam = l.hasParam'
-
-def hasMVar' : Level → Bool
-  | .mvar .. => true
-  | .zero | .param .. => false
-  | .succ l => l.hasMVar'
-  | .max l₁ l₂ | .imax l₁ l₂ => l₁.hasMVar' || l₂.hasMVar'
-
-/-- This was false prior to the fix of lean4#8554; it should now be provable
-using `mkData_eq` and friends, but this has not been done yet -/
-@[simp] axiom hasMVar_eq (l : Level) : l.hasMVar = l.hasMVar'
 
 /-- This is because the `BEq` instance is implemented in C++ -/
 @[instance] axiom instLawfulBEqLevel : LawfulBEq Level

--- a/Lean4Lean/Verify/Level.lean
+++ b/Lean4Lean/Verify/Level.lean
@@ -55,43 +55,30 @@ theorem mkData_depth (H : d < 2 ^ 24) : (mkData h d hmv hp).depth.toNat = d := b
     d.toUInt64.toBitVec <<< 40#64) >>> 40#64 = d.toUInt64.toBitVec
   bv_decide
 
-theorem mkData_hasParam : (mkData h d hmv hp).hasParam = hp := by
+theorem mkData_flags :
+    (mkData h d hmv hp).hasMVar = hmv ∧ (mkData h d hmv hp).hasParam = hp := by
   rw [mkData_eq, mkData']
-  simp [Data.hasParam, (· == ·), ← UInt64.toBitVec_inj]
+  simp [Data.hasMVar, Data.hasParam, (· == ·), ← UInt64.toBitVec_inj]
   have hd : min d (2 ^ 24 - 1) ≤ 2 ^ 24 - 1 := Nat.min_le_right ..
-  generalize min d (2 ^ 24 - 1) = d at hd
-  have : d.toUInt64.toNat = d := by simp; omega
-  have : d.toUInt64.toBitVec ≤ 0xffffff#64 := (this ▸ hd :)
+  generalize min d (2 ^ 24 - 1) = d' at hd
+  have hnat : d'.toUInt64.toNat = d' := by simp; omega
+  have : d'.toUInt64.toBitVec ≤ 0xffffff#64 := (hnat ▸ hd :)
   have : h.toUInt32.toUInt64.toBitVec ≤ 0xffffffff#64 := Nat.le_of_lt_succ h.toUInt32.1.1.2
   have hb : ∀ (b : Bool), b.toUInt64.toBitVec ≤ 1#64 := by decide
   have := hb hmv; have := hb hp
-  let L := ((
+  let data :=
     h.toUInt32.toUInt64.toBitVec +
     hmv.toUInt64.toBitVec <<< 32#64 +
     hp.toUInt64.toBitVec <<< 33#64 +
-    d.toUInt64.toBitVec <<< 40#64) >>> 33#64) &&& 1#64
-  change decide (L = 1#64) = hp
-  rw [show L = hp.toUInt64.toBitVec by bv_decide]
-  cases hp <;> decide
+    d'.toUInt64.toBitVec <<< 40#64
+  change
+    decide (data >>> 32#64 &&& 1#64 = 1#64) = hmv ∧
+    decide (data >>> 33#64 &&& 1#64 = 1#64) = hp
+  bv_decide
 
-theorem mkData_hasMVar : (mkData h d hmv hp).hasMVar = hmv := by
-  rw [mkData_eq, mkData']
-  simp [Data.hasMVar, (· == ·), ← UInt64.toBitVec_inj]
-  have hd : min d (2 ^ 24 - 1) ≤ 2 ^ 24 - 1 := Nat.min_le_right ..
-  generalize min d (2 ^ 24 - 1) = d at hd
-  have : d.toUInt64.toNat = d := by simp; omega
-  have : d.toUInt64.toBitVec ≤ 0xffffff#64 := (this ▸ hd :)
-  have : h.toUInt32.toUInt64.toBitVec ≤ 0xffffffff#64 := Nat.le_of_lt_succ h.toUInt32.1.1.2
-  have hb : ∀ (b : Bool), b.toUInt64.toBitVec ≤ 1#64 := by decide
-  have := hb hmv; have := hb hp
-  let L := ((
-    h.toUInt32.toUInt64.toBitVec +
-    hmv.toUInt64.toBitVec <<< 32#64 +
-    hp.toUInt64.toBitVec <<< 33#64 +
-    d.toUInt64.toBitVec <<< 40#64) >>> 32#64) &&& 1#64
-  change decide (L = 1#64) = hmv
-  rw [show L = hmv.toUInt64.toBitVec by bv_decide]
-  cases hmv <;> decide
+theorem mkData_hasParam : (mkData h d hmv hp).hasParam = hp := mkData_flags.2
+
+theorem mkData_hasMVar : (mkData h d hmv hp).hasMVar = hmv := mkData_flags.1
 
 def hasParam' : Level → Bool
   | .param .. => true

--- a/Lean4Lean/Verify/Level.lean
+++ b/Lean4Lean/Verify/Level.lean
@@ -39,7 +39,7 @@ set_option allowUnsafeReducibility true
 attribute [local reducible] Data
 
 theorem mkData_depth (H : d < 2 ^ 24) : (mkData h d hmv hp).depth.toNat = d := by
-  rw [mkData_eq, mkData', if_neg (Nat.not_lt.2 (Nat.le_sub_one_of_lt H)), Data.depth]
+  rw [mkData_eq, mkData', Nat.min_eq_left (Nat.le_sub_one_of_lt H), Data.depth]
   have : d.toUInt64.toUInt32.toNat = d := by simp; omega
   refine .trans ?_ this; congr 2
   rw [← UInt64.toBitVec_inj]
@@ -55,9 +55,13 @@ theorem mkData_depth (H : d < 2 ^ 24) : (mkData h d hmv hp).depth.toNat = d := b
     d.toUInt64.toBitVec <<< 40#64) >>> 40#64 = d.toUInt64.toBitVec
   bv_decide
 
-theorem mkData_hasParam (H : d < 2 ^ 24) : (mkData h d hmv hp).hasParam = hp := by
-  rw [mkData_eq, mkData', if_neg (Nat.not_lt.2 (Nat.le_sub_one_of_lt H))]
+theorem mkData_hasParam : (mkData h d hmv hp).hasParam = hp := by
+  rw [mkData_eq, mkData']
   simp [Data.hasParam, (· == ·), ← UInt64.toBitVec_inj]
+  have hd : min d (2 ^ 24 - 1) ≤ 2 ^ 24 - 1 := Nat.min_le_right ..
+  generalize min d (2 ^ 24 - 1) = d at hd
+  have : d.toUInt64.toNat = d := by simp; omega
+  have : d.toUInt64.toBitVec ≤ 0xffffff#64 := (this ▸ hd :)
   have : h.toUInt32.toUInt64.toBitVec ≤ 0xffffffff#64 := Nat.le_of_lt_succ h.toUInt32.1.1.2
   have hb : ∀ (b : Bool), b.toUInt64.toBitVec ≤ 1#64 := by decide
   have := hb hmv; have := hb hp
@@ -70,9 +74,13 @@ theorem mkData_hasParam (H : d < 2 ^ 24) : (mkData h d hmv hp).hasParam = hp := 
   rw [show L = hp.toUInt64.toBitVec by bv_decide]
   cases hp <;> decide
 
-theorem mkData_hasMVar (H : d < 2 ^ 24) : (mkData h d hmv hp).hasMVar = hmv := by
-  rw [mkData_eq, mkData', if_neg (Nat.not_lt.2 (Nat.le_sub_one_of_lt H))]
+theorem mkData_hasMVar : (mkData h d hmv hp).hasMVar = hmv := by
+  rw [mkData_eq, mkData']
   simp [Data.hasMVar, (· == ·), ← UInt64.toBitVec_inj]
+  have hd : min d (2 ^ 24 - 1) ≤ 2 ^ 24 - 1 := Nat.min_le_right ..
+  generalize min d (2 ^ 24 - 1) = d at hd
+  have : d.toUInt64.toNat = d := by simp; omega
+  have : d.toUInt64.toBitVec ≤ 0xffffff#64 := (this ▸ hd :)
   have : h.toUInt32.toUInt64.toBitVec ≤ 0xffffffff#64 := Nat.le_of_lt_succ h.toUInt32.1.1.2
   have hb : ∀ (b : Bool), b.toUInt64.toBitVec ≤ 1#64 := by decide
   have := hb hmv; have := hb hp
@@ -84,6 +92,28 @@ theorem mkData_hasMVar (H : d < 2 ^ 24) : (mkData h d hmv hp).hasMVar = hmv := b
   change decide (L = 1#64) = hmv
   rw [show L = hmv.toUInt64.toBitVec by bv_decide]
   cases hmv <;> decide
+
+def hasParam' : Level → Bool
+  | .param .. => true
+  | .zero | .mvar .. => false
+  | .succ l => l.hasParam'
+  | .max l₁ l₂ | .imax l₁ l₂ => l₁.hasParam' || l₂.hasParam'
+
+/-- The cached `hasParam` bit agrees with structural traversal. -/
+@[simp] theorem hasParam_eq (l : Level) : l.hasParam = l.hasParam' := by
+  change l.data.hasParam = l.hasParam'
+  induction l <;> simp [Level.data, hasParam', mkData_hasParam, *]
+
+def hasMVar' : Level → Bool
+  | .mvar .. => true
+  | .zero | .param .. => false
+  | .succ l => l.hasMVar'
+  | .max l₁ l₂ | .imax l₁ l₂ => l₁.hasMVar' || l₂.hasMVar'
+
+/-- The cached `hasMVar` bit agrees with structural traversal. -/
+@[simp] theorem hasMVar_eq (l : Level) : l.hasMVar = l.hasMVar' := by
+  change l.data.hasMVar = l.hasMVar'
+  induction l <;> simp [Level.data, hasMVar', mkData_hasMVar, *]
 
 theorem ofLevel_of_not_hasParam (Us) {l : Level}
     (hl : l.hasParam' = false) (hmv : l.hasMVar' = false) :


### PR DESCRIPTION
This PR replaces the `Level.hasParam_eq` and `Level.hasMVar_eq` axioms with proofs derived from `Level.mkData_eq`, and moves them, along with the structural `hasParam'`/`hasMVar'` definitions, out of `Verify/Axioms.lean` into `Verify/Level.lean`, mirroring what https://github.com/digama0/lean4lean/pull/19 (Prove Expr cached flag correctness) did for the Expr flags. Closes https://github.com/digama0/lean4lean/issues/24 (Prove Level cached-flag correctness).

Please look closely at one part of this, because it goes beyond what the issue asked for and it changes what `mkData_eq` asserts. As stated, the two equalities are not just unprovable from `mkData_eq`, they are refutable, and fixing that meant changing the overflow branch of the `mkData'` model.

The old model was a character-for-character copy of the Lean definition of `mkData` that preceded the `@[extern]` one:

```lean
def mkData' (h : UInt64) (depth : Nat := 0) (hasMVar hasParam : Bool := false) : Level.Data :=
  if depth > Nat.pow 2 24 - 1 then panic! "universe level depth is too big"
  else ...
```

That is, it was a copy of the bug: `panic!` evaluates to `default = 0`, so the branch drops both flag bits, which is exactly the non-conservativity reported in https://github.com/leanprover/lean4/pull/8554 (fix: soundness bug in {Expr, Level}.data). `Level.data` for `.succ u` passes `u.data.depth.toNat + 1` and `Data.depth` reads 24 bits, so a level of cached depth `2 ^ 24 - 1` exists and its successor overflows. Hence `Level.succ (succ^[2 ^ 24 - 1] (.param x))` has `hasParam = false` but `hasParam' = true`, and `mkData_eq` together with the old `hasParam_eq` axiom proves `False`. I checked that in Lean; the derivation is at the end of this description. The same goes for `hasMVar_eq` separately.

The kernel as it stands cannot reach that state. `Level.mkData` is `opaque` with `@[extern "lean_level_mk_data"]`, and since https://github.com/leanprover/lean4/pull/8559 (fix: block adversarial exploit of non-aborting `assert!`) the C++ calls `lean_internal_panic` on an overflowing depth, which prints to a saved stderr handle and calls `exit(1)`. It never returns a `Level.Data`. https://github.com/leanprover/lean4/pull/8560 (fix: block potential adversarial exploit of non-aborting `assert!`) did the same for `Expr`.

So on that branch there is no value to transcribe, and a total Lean model has to invent one. This PR invents the saturating one:

```lean
def mkData' (h : UInt64) (depth : Nat := 0) (hasMVar hasParam : Bool := false) : Level.Data :=
  h.toUInt32.toUInt64 +
  hasMVar.toUInt64.shiftLeft 32 +
  hasParam.toUInt64.shiftLeft 33 +
  (min depth (2 ^ 24 - 1)).toUInt64.shiftLeft 40
```

which keeps the flag bits and makes both equalities hold unconditionally. Two things to be clear about, both now recorded in the `mkData'` docstring:

* This is a chosen total specification for an opaque constant, not a transcription of the implementation. It agrees with the C++ wherever the C++ returns, so results proved from it transfer for runs that do not abort. It does not model termination, and nothing here says a level that deep is constructible in a running Lean.
* It is emphatically not a claim that the kernel saturates. The kernel aborts, and that is the behaviour this models around, not against. Saturation was proposed for the kernel in #8554 and not merged, but that decision was about what the kernel should *do*, which is a different question from which total function to assign to a branch where the kernel does nothing. The only requirements on that assignment are that it agree with the kernel wherever the kernel returns, and that it keep the cached fields conservative. Saturation is the natural pick meeting both; `panic!`/`0` fails the second and is why the current axioms are inconsistent.

A consequence is that `mkData_hasParam` and `mkData_hasMVar` no longer need their `d < 2 ^ 24` hypotheses; they are now projections of a shared `mkData_flags`, matching `Expr.mkData_flags`. `mkData_depth` still needs the hypothesis.

The structural definitions and the downstream API are unchanged, and the axiom footprint matches the Expr precedent:

```
'Lean.Level.hasParam_eq' depends on axioms: [propext, Classical.choice, Quot.sound,
 Lean.Level.mkData_eq, Lean.Level.mkData_flags._native.bv_decide.ax_1_10]
'Lean.Level.hasMVar_eq' depends on axioms: [propext, Classical.choice, Quot.sound,
 Lean.Level.mkData_eq, Lean.Level.mkData_flags._native.bv_decide.ax_1_10]
```

Not addressed here: `Expr.looseBVarRange_eq` is still an axiom carrying the same stale "should now be provable" comment, and it is refutable against the current `Expr.mkData'` for the same reason. `.bvar i` with `i + 1 > 2 ^ 20 - 1` fails the `assert!`, so the data is `0` and `looseBVarRange = 0` while `looseBVarRange' = i + 1`. The Expr *flags* were unaffected, since `0` is conservative for them, which is why #19 went through.

<details>
<summary>Derivation of `False` from the previous pair of axioms</summary>

Checked against the parent commit, 7842f38:

```lean
import Lean4Lean.Verify.Level

namespace Lean.Level

def succs : Nat → Level → Level
  | 0, l => l
  | n+1, l => .succ (succs n l)

theorem succs_data (x : Name) : ∀ n, n < 2^24 →
    (succs n (.param x)).data.depth.toNat = n ∧ (succs n (.param x)).data.hasParam = true
  | 0, _ => by
    show (Level.param x).data.depth.toNat = _ ∧ (Level.param x).data.hasParam = _
    simp only [Level.data]
    exact ⟨mkData_depth (by omega), mkData_hasParam (by omega)⟩
  | n+1, h => by
    have ⟨ih1, ih2⟩ := succs_data x n (by omega)
    show (Level.succ (succs n (.param x))).data.depth.toNat = _ ∧
      (Level.succ (succs n (.param x))).data.hasParam = _
    simp only [Level.data, ih1, ih2]
    exact ⟨mkData_depth h, mkData_hasParam h⟩

/-- One `succ` past the representable depth loses the `hasParam` bit. -/
theorem overflow (u : Level) (h : u.data.depth.toNat = 2^24 - 1) :
    (Level.succ u).hasParam = false := by
  show (Level.succ u).data.hasParam = false
  simp only [Level.data, h]
  rw [mkData_eq, mkData', if_pos (Nat.lt_succ_self _)]
  rfl

theorem hasParam'_succ (u : Level) : (Level.succ u).hasParam' = u.hasParam' := rfl

theorem hasParam'_succs (x : Name) : ∀ n, (succs n (.param x)).hasParam' = true
  | 0 => rfl
  | n+1 => hasParam'_succs x n

theorem bad : False := by
  have h := hasParam_eq (.succ (succs (2^24 - 1) (.param `x)))
  rw [overflow _ (succs_data _ _ (by omega)).1] at h
  rw [hasParam'_succ, hasParam'_succs] at h
  exact Bool.noConfusion h

end Lean.Level
```

</details>

🤖 Prepared with Claude Code