### PR TITLE
refactor: migrate to the new do elaborator

### DIFF
--- a/Lean4Lean/EquivManager.lean
+++ b/Lean4Lean/EquivManager.lean
@@ -1,15 +1,6 @@
 import Batteries.Data.UnionFind.Basic
 import Lean4Lean.PtrEq
 
-/-
-The `Lean4Lean.Verify` proofs about the definitions below are written against the term shape
-the legacy `do` elaborator produces, destructuring with `extract_lets` the join points it
-emits as `let`s. leanprover/lean4#13305 made the new `do` elaborator the default in v4.32.0,
-and it emits `have __do_jp` join points and inlines the `if` chains instead. Pin the legacy
-elaborator here until those proofs are migrated (digama0/lean4lean#31).
--/
-set_option backward.do.legacy true
-
 namespace Lean4Lean
 open Lean
 

--- a/Lean4Lean/Experimental/ShapeLogRel.lean
+++ b/Lean4Lean/Experimental/ShapeLogRel.lean
@@ -414,6 +414,8 @@ def ShapeFun.plift (lift : α → β × Option β) (x : List (α × α)) :
   (x.filterMap fun (a, b) => (lift a).2.map fun a => (a, (lift b).1),
    x.mapM fun (a, b) => (lift b).2.map fun b => ((lift a).1, b))
 
+-- Keep the result type visible through the bind chain: with the new `do` elaborator,
+-- constructor terms otherwise remain at `ShapeS (Shape m)` and destabilize the proofs below.
 def Shape.plift : ∀ {n m}, Shape n → Shape m × Option (Shape m)
   | 0, _, .sort r | _+1, _, .sort r => (.sort r, some (.sort r))
   | 0, _, .bot | _+1, _, .bot => (.bot, some .bot)
@@ -434,13 +436,13 @@ def Shape.plift : ∀ {n m}, Shape n → Shape m × Option (Shape m)
   | _+1, _+1, .indTy => (.indTy, some .indTy)
 
 omit [Params] in
-@[simp] private theorem List.mapM_some (f : α → β) (l : List α) :
+private theorem List.mapM_some (f : α → β) (l : List α) :
     l.mapM (fun x => some (f x)) = some (l.map f) := by
   induction l with
   | nil => rfl
   | cons a l ih => simp only [List.mapM_cons, ih]; rfl
 
-attribute [local simp] Option.bind_eq_some_iff
+attribute [local simp] List.mapM_some
 
 omit [Params] in
 theorem Shape.plift_eq_lift (le : n ≤ m) {s : Shape n} :
@@ -454,7 +456,6 @@ theorem Shape.plift_eq_lift (le : n ≤ m) {s : Shape n} :
       exact .rfl fun _ _ => rfl
   unfold plift; split <;> simp [lift] at le ⊢ <;>
     simp [plift_eq_lift le, go plift_eq_lift le]
-  all_goals rfl
 
 omit [Params] in
 theorem ShapeFun.plift_eq_lift (le : n ≤ m) {s : ShapeFun n} :
@@ -539,9 +540,9 @@ theorem Shape.plift_plift (le : n₁ ≤ n₂ ∨ n₃ ≤ n₂) {s : Shape n₁
       simp [Option.map_eq_bind, Option.bind_assoc, Function.comp_def, ih]
   cases s with simp [plift, ih, go, Function.comp_def, Option.bind_assoc]
   | forallE s f =>
-    cases (s.plift (m := n₂)).2 <;> simp
-    rename_i s'
-    cases (ShapeFun.plift (Shape.plift (m := n₂)) f).2 <;> simp
+    cases (s.plift (m := n₂)).2 with
+    | none => simp
+    | some => cases (ShapeFun.plift (Shape.plift (m := n₂)) f).2 <;> simp
   | ctor => rw [← List.mapM_mapM_option, Option.bind_assoc]
 
 omit [Params] in
@@ -650,6 +651,7 @@ protected theorem Shape.Compat.plift {x y : Shape n} :
 def ShapeFun.olift (lift : α → Option β) (x : List (α × α)) : Option (List (β × β)) :=
   x.mapM fun (a, b) => return (← lift a, ← lift b)
 
+-- As in `Shape.plift`, explicit binds preserve the recursive `Shape` result type.
 def Shape.olift : ∀ {n m}, Shape n → Option (Shape m)
   | 0, _, .sort r | _+1, _, .sort r => some (.sort r)
   | 0, _, .bot | _+1, _, .bot => some .bot
@@ -675,7 +677,6 @@ theorem Shape.olift_eq_lift (le : n ≤ m) {s : Shape n} :
     exact .rfl fun _ _ => rfl
   unfold olift; split <;> simp [lift] at le ⊢ <;>
     simp [olift_eq_lift le, go olift_eq_lift le]
-  all_goals rfl
 
 omit [Params] in
 theorem ShapeFun.olift_eq_lift (le : n ≤ m) {s : ShapeFun n} :

--- a/Lean4Lean/Experimental/ShapeLogRel.lean
+++ b/Lean4Lean/Experimental/ShapeLogRel.lean
@@ -1,5 +1,14 @@
 import Lean4Lean.Experimental.SExpr
 
+/-
+`Shape.plift` and friends below are written in `Option`-monad `do`/`return` notation, and
+the proofs about them `simp` through the exact term that notation elaborates to.
+leanprover/lean4#13305 made the new `do` elaborator the default in v4.32.0, which reshapes
+those terms. Pin the legacy elaborator here until the proofs are migrated
+(digama0/lean4lean#31).
+-/
+set_option backward.do.legacy true
+
 namespace Lean4Lean
 open Lean4Lean
 
@@ -414,35 +423,19 @@ def ShapeFun.plift (lift : α → β × Option β) (x : List (α × α)) :
   (x.filterMap fun (a, b) => (lift a).2.map fun a => (a, (lift b).1),
    x.mapM fun (a, b) => (lift b).2.map fun b => ((lift a).1, b))
 
--- Keep the result type visible through the bind chain: with the new `do` elaborator,
--- constructor terms otherwise remain at `ShapeS (Shape m)` and destabilize the proofs below.
 def Shape.plift : ∀ {n m}, Shape n → Shape m × Option (Shape m)
   | 0, _, .sort r | _+1, _, .sort r => (.sort r, some (.sort r))
   | 0, _, .bot | _+1, _, .bot => (.bot, some .bot)
   | _+1, 0, _ => (.bot, none)
-  | _+1, m+1, .forallE s f =>
+  | _+1, _+1, .forallE s f =>
     let (s₀, s₁) := s.plift
     let (f₀, f₁) := ShapeFun.plift plift f
-    (show Shape (m+1) from .forallE s₀ f₀,
-      s₁.bind fun s => f₁.bind fun f => some (show Shape (m+1) from .forallE s f))
-  | _+1, m+1, .lam f =>
+    (.forallE s₀ f₀, return .forallE (← s₁) (← f₁))
+  | _+1, _+1, .lam f =>
     let (f₀, f₁) := ShapeFun.plift plift f
-    (show Shape (m+1) from .lam f₀,
-      f₁.bind fun f => some (show Shape (m+1) from .lam f))
-  | _+1, m+1, .ctor c l =>
-    (show Shape (m+1) from .ctor c (l.map (fun x => (Shape.plift (m := m) x).1)),
-      (l.mapM fun x => (Shape.plift (m := m) x).2).bind fun l =>
-        some (show Shape (m+1) from .ctor c l))
+    (.lam f₀, return .lam (← f₁))
+  | _+1, _+1, .ctor c l => (.ctor c (l.map (·.plift.1)), return .ctor c (← l.mapM (·.plift.2)))
   | _+1, _+1, .indTy => (.indTy, some .indTy)
-
-omit [Params] in
-private theorem List.mapM_some (f : α → β) (l : List α) :
-    l.mapM (fun x => some (f x)) = some (l.map f) := by
-  induction l with
-  | nil => rfl
-  | cons a l ih => simp only [List.mapM_cons, ih]; rfl
-
-attribute [local simp] List.mapM_some
 
 omit [Params] in
 theorem Shape.plift_eq_lift (le : n ≤ m) {s : Shape n} :
@@ -454,8 +447,8 @@ theorem Shape.plift_eq_lift (le : n ≤ m) {s : Shape n} :
     · rw [← List.filterMap_eq_map]; rfl
     · rw [List.mapM_eq_some, List.forall₂_map_right_iff]
       exact .rfl fun _ _ => rfl
-  unfold plift; split <;> simp [lift] at le ⊢ <;>
-    simp [plift_eq_lift le, go plift_eq_lift le]
+  unfold plift; split <;> simp [lift] at le ⊢ <;> simp [plift_eq_lift le, go plift_eq_lift le]
+  · exact ⟨_, List.mapM_pure, rfl⟩
 
 omit [Params] in
 theorem ShapeFun.plift_eq_lift (le : n ≤ m) {s : ShapeFun n} :
@@ -476,7 +469,7 @@ theorem Shape.plift_lift (le : n ≤ m) {s : Shape n} :
   · simp [plift_lift le, go plift_lift le]
   · simp [go plift_lift le]
   · simp [Function.comp_def, plift_lift le]
-    exact ⟨_, List.mapM_some _ _, congrArg _ (List.map_id _)⟩
+    exact ⟨_, List.mapM_pure, List.map_id _ ▸ rfl⟩
 
 omit [Params] in
 @[simp] theorem Shape.bot_plift : (bot (n := n)).plift (m := m) = (bot, some bot) := by
@@ -515,15 +508,9 @@ theorem Shape.plift_plift (le : n₁ ≤ n₂ ∨ n₃ ≤ n₂) {s : Shape n₁
   cases n₃ with
   | zero =>
     cases s with simp [plift]
-    | forallE s f =>
-      cases s.plift.2 <;> cases (ShapeFun.plift plift f).2 <;>
-        simp only [Option.bind_none, Option.bind_some] <;> rfl
-    | lam f =>
-      cases (ShapeFun.plift plift f).2 <;>
-        simp only [Option.bind_none, Option.bind_some] <;> rfl
-    | ctor _ l =>
-      cases l.mapM (·.plift (m := n₂) |>.2) <;>
-        simp only [Option.bind_none, Option.bind_some] <;> rfl
+    | forallE s f => cases s.plift.2 <;> simp; cases (ShapeFun.plift plift f).2 <;> simp [plift]
+    | lam f => cases (ShapeFun.plift plift f).2 <;> simp [plift]
+    | ctor _ l => cases eq: l.mapM (·.plift (m := n₂) |>.2) <;> simp [plift]
   | succ n₃
   simp at h1 h2; replace ih {s} := ih (s := s) h1 h2
   let rec go {s : ShapeFun n₁} :
@@ -539,11 +526,11 @@ theorem Shape.plift_plift (le : n₁ ≤ n₂ ∨ n₃ ≤ n₂) {s : Shape n₁
     · rw [List.mapM_mapM_option]; congr 1; ext1
       simp [Option.map_eq_bind, Option.bind_assoc, Function.comp_def, ih]
   cases s with simp [plift, ih, go, Function.comp_def, Option.bind_assoc]
-  | forallE s f =>
-    cases (s.plift (m := n₂)).2 with
-    | none => simp
-    | some => cases (ShapeFun.plift (Shape.plift (m := n₂)) f).2 <;> simp
-  | ctor => rw [← List.mapM_mapM_option, Option.bind_assoc]
+  | forallE => congr 1; ext; rw [Option.bind_comm]
+  | ctor _ l =>
+    rw [← Option.bind_assoc]; congr 1
+    induction l with simp | cons a l ihl
+    simp [Option.bind_assoc, ihl]; congr 1; ext1; rw [Option.bind_comm]
 
 omit [Params] in
 theorem ShapeFun.plift_plift (le : n₁ ≤ n₂ ∨ n₃ ≤ n₂) {s : ShapeFun n₁} :
@@ -651,19 +638,13 @@ protected theorem Shape.Compat.plift {x y : Shape n} :
 def ShapeFun.olift (lift : α → Option β) (x : List (α × α)) : Option (List (β × β)) :=
   x.mapM fun (a, b) => return (← lift a, ← lift b)
 
--- As in `Shape.plift`, explicit binds preserve the recursive `Shape` result type.
 def Shape.olift : ∀ {n m}, Shape n → Option (Shape m)
   | 0, _, .sort r | _+1, _, .sort r => some (.sort r)
   | 0, _, .bot | _+1, _, .bot => some .bot
   | _+1, 0, _ => none
-  | _+1, m+1, .forallE s f =>
-    (s.olift (m := m)).bind fun s => (ShapeFun.olift (Shape.olift (m := m)) f).bind fun f =>
-      some (show Shape (m+1) from .forallE s f)
-  | _+1, m+1, .lam f =>
-    (ShapeFun.olift (Shape.olift (m := m)) f).bind fun f => some (show Shape (m+1) from .lam f)
-  | _+1, m+1, .ctor c l =>
-    (l.mapM fun x => Shape.olift (m := m) x).bind fun l =>
-      some (show Shape (m+1) from .ctor c l)
+  | _+1, _+1, .forallE s f => return .forallE (← s.olift) (← ShapeFun.olift olift f)
+  | _+1, _+1, .lam f => return .lam (← ShapeFun.olift olift f)
+  | _+1, _+1, .ctor c l => return .ctor c (← l.mapM (·.olift))
   | _+1, _+1, .indTy => some .indTy
 
 omit [Params] in
@@ -675,8 +656,8 @@ theorem Shape.olift_eq_lift (le : n ≤ m) {s : Shape n} :
     simp only [ShapeFun.olift, ShapeFun.lift, IH le]
     rw [List.mapM_eq_some, List.forall₂_map_right_iff]
     exact .rfl fun _ _ => rfl
-  unfold olift; split <;> simp [lift] at le ⊢ <;>
-    simp [olift_eq_lift le, go olift_eq_lift le]
+  unfold olift; split <;> simp [lift] at le ⊢ <;> simp [olift_eq_lift le, go olift_eq_lift le]
+  · exact ⟨_, List.mapM_pure, rfl⟩
 
 omit [Params] in
 theorem ShapeFun.olift_eq_lift (le : n ≤ m) {s : ShapeFun n} :

--- a/Lean4Lean/Experimental/ShapeLogRel.lean
+++ b/Lean4Lean/Experimental/ShapeLogRel.lean
@@ -1,14 +1,5 @@
 import Lean4Lean.Experimental.SExpr
 
-/-
-`Shape.plift` and friends below are written in `Option`-monad `do`/`return` notation, and
-the proofs about them `simp` through the exact term that notation elaborates to.
-leanprover/lean4#13305 made the new `do` elaborator the default in v4.32.0, which reshapes
-those terms. Pin the legacy elaborator here until the proofs are migrated
-(digama0/lean4lean#31).
--/
-set_option backward.do.legacy true
-
 namespace Lean4Lean
 open Lean4Lean
 
@@ -427,15 +418,29 @@ def Shape.plift : ∀ {n m}, Shape n → Shape m × Option (Shape m)
   | 0, _, .sort r | _+1, _, .sort r => (.sort r, some (.sort r))
   | 0, _, .bot | _+1, _, .bot => (.bot, some .bot)
   | _+1, 0, _ => (.bot, none)
-  | _+1, _+1, .forallE s f =>
+  | _+1, m+1, .forallE s f =>
     let (s₀, s₁) := s.plift
     let (f₀, f₁) := ShapeFun.plift plift f
-    (.forallE s₀ f₀, return .forallE (← s₁) (← f₁))
-  | _+1, _+1, .lam f =>
+    (show Shape (m+1) from .forallE s₀ f₀,
+      s₁.bind fun s => f₁.bind fun f => some (show Shape (m+1) from .forallE s f))
+  | _+1, m+1, .lam f =>
     let (f₀, f₁) := ShapeFun.plift plift f
-    (.lam f₀, return .lam (← f₁))
-  | _+1, _+1, .ctor c l => (.ctor c (l.map (·.plift.1)), return .ctor c (← l.mapM (·.plift.2)))
+    (show Shape (m+1) from .lam f₀,
+      f₁.bind fun f => some (show Shape (m+1) from .lam f))
+  | _+1, m+1, .ctor c l =>
+    (show Shape (m+1) from .ctor c (l.map (fun x => (Shape.plift (m := m) x).1)),
+      (l.mapM fun x => (Shape.plift (m := m) x).2).bind fun l =>
+        some (show Shape (m+1) from .ctor c l))
   | _+1, _+1, .indTy => (.indTy, some .indTy)
+
+omit [Params] in
+@[simp] private theorem List.mapM_some (f : α → β) (l : List α) :
+    l.mapM (fun x => some (f x)) = some (l.map f) := by
+  induction l with
+  | nil => rfl
+  | cons a l ih => simp only [List.mapM_cons, ih]; rfl
+
+attribute [local simp] Option.bind_eq_some_iff
 
 omit [Params] in
 theorem Shape.plift_eq_lift (le : n ≤ m) {s : Shape n} :
@@ -447,8 +452,9 @@ theorem Shape.plift_eq_lift (le : n ≤ m) {s : Shape n} :
     · rw [← List.filterMap_eq_map]; rfl
     · rw [List.mapM_eq_some, List.forall₂_map_right_iff]
       exact .rfl fun _ _ => rfl
-  unfold plift; split <;> simp [lift] at le ⊢ <;> simp [plift_eq_lift le, go plift_eq_lift le]
-  · exact ⟨_, List.mapM_pure, rfl⟩
+  unfold plift; split <;> simp [lift] at le ⊢ <;>
+    simp [plift_eq_lift le, go plift_eq_lift le]
+  all_goals rfl
 
 omit [Params] in
 theorem ShapeFun.plift_eq_lift (le : n ≤ m) {s : ShapeFun n} :
@@ -469,7 +475,7 @@ theorem Shape.plift_lift (le : n ≤ m) {s : Shape n} :
   · simp [plift_lift le, go plift_lift le]
   · simp [go plift_lift le]
   · simp [Function.comp_def, plift_lift le]
-    exact ⟨_, List.mapM_pure, List.map_id _ ▸ rfl⟩
+    exact ⟨_, List.mapM_some _ _, congrArg _ (List.map_id _)⟩
 
 omit [Params] in
 @[simp] theorem Shape.bot_plift : (bot (n := n)).plift (m := m) = (bot, some bot) := by
@@ -508,9 +514,15 @@ theorem Shape.plift_plift (le : n₁ ≤ n₂ ∨ n₃ ≤ n₂) {s : Shape n₁
   cases n₃ with
   | zero =>
     cases s with simp [plift]
-    | forallE s f => cases s.plift.2 <;> simp; cases (ShapeFun.plift plift f).2 <;> simp [plift]
-    | lam f => cases (ShapeFun.plift plift f).2 <;> simp [plift]
-    | ctor _ l => cases eq: l.mapM (·.plift (m := n₂) |>.2) <;> simp [plift]
+    | forallE s f =>
+      cases s.plift.2 <;> cases (ShapeFun.plift plift f).2 <;>
+        simp only [Option.bind_none, Option.bind_some] <;> rfl
+    | lam f =>
+      cases (ShapeFun.plift plift f).2 <;>
+        simp only [Option.bind_none, Option.bind_some] <;> rfl
+    | ctor _ l =>
+      cases l.mapM (·.plift (m := n₂) |>.2) <;>
+        simp only [Option.bind_none, Option.bind_some] <;> rfl
   | succ n₃
   simp at h1 h2; replace ih {s} := ih (s := s) h1 h2
   let rec go {s : ShapeFun n₁} :
@@ -526,11 +538,11 @@ theorem Shape.plift_plift (le : n₁ ≤ n₂ ∨ n₃ ≤ n₂) {s : Shape n₁
     · rw [List.mapM_mapM_option]; congr 1; ext1
       simp [Option.map_eq_bind, Option.bind_assoc, Function.comp_def, ih]
   cases s with simp [plift, ih, go, Function.comp_def, Option.bind_assoc]
-  | forallE => congr 1; ext; rw [Option.bind_comm]
-  | ctor _ l =>
-    rw [← Option.bind_assoc]; congr 1
-    induction l with simp | cons a l ihl
-    simp [Option.bind_assoc, ihl]; congr 1; ext1; rw [Option.bind_comm]
+  | forallE s f =>
+    cases (s.plift (m := n₂)).2 <;> simp
+    rename_i s'
+    cases (ShapeFun.plift (Shape.plift (m := n₂)) f).2 <;> simp
+  | ctor => rw [← List.mapM_mapM_option, Option.bind_assoc]
 
 omit [Params] in
 theorem ShapeFun.plift_plift (le : n₁ ≤ n₂ ∨ n₃ ≤ n₂) {s : ShapeFun n₁} :
@@ -642,9 +654,14 @@ def Shape.olift : ∀ {n m}, Shape n → Option (Shape m)
   | 0, _, .sort r | _+1, _, .sort r => some (.sort r)
   | 0, _, .bot | _+1, _, .bot => some .bot
   | _+1, 0, _ => none
-  | _+1, _+1, .forallE s f => return .forallE (← s.olift) (← ShapeFun.olift olift f)
-  | _+1, _+1, .lam f => return .lam (← ShapeFun.olift olift f)
-  | _+1, _+1, .ctor c l => return .ctor c (← l.mapM (·.olift))
+  | _+1, m+1, .forallE s f =>
+    (s.olift (m := m)).bind fun s => (ShapeFun.olift (Shape.olift (m := m)) f).bind fun f =>
+      some (show Shape (m+1) from .forallE s f)
+  | _+1, m+1, .lam f =>
+    (ShapeFun.olift (Shape.olift (m := m)) f).bind fun f => some (show Shape (m+1) from .lam f)
+  | _+1, m+1, .ctor c l =>
+    (l.mapM fun x => Shape.olift (m := m) x).bind fun l =>
+      some (show Shape (m+1) from .ctor c l)
   | _+1, _+1, .indTy => some .indTy
 
 omit [Params] in
@@ -656,8 +673,9 @@ theorem Shape.olift_eq_lift (le : n ≤ m) {s : Shape n} :
     simp only [ShapeFun.olift, ShapeFun.lift, IH le]
     rw [List.mapM_eq_some, List.forall₂_map_right_iff]
     exact .rfl fun _ _ => rfl
-  unfold olift; split <;> simp [lift] at le ⊢ <;> simp [olift_eq_lift le, go olift_eq_lift le]
-  · exact ⟨_, List.mapM_pure, rfl⟩
+  unfold olift; split <;> simp [lift] at le ⊢ <;>
+    simp [olift_eq_lift le, go olift_eq_lift le]
+  all_goals rfl
 
 omit [Params] in
 theorem ShapeFun.olift_eq_lift (le : n ≤ m) {s : ShapeFun n} :

--- a/Lean4Lean/TypeChecker.lean
+++ b/Lean4Lean/TypeChecker.lean
@@ -7,15 +7,6 @@ import Lean4Lean.ForEachExprV
 import Lean4Lean.EquivManager
 import Lean4Lean.FuelConfig
 
-/-
-The `Lean4Lean.Verify` proofs about the definitions below are written against the term shape
-the legacy `do` elaborator produces, destructuring with `extract_lets` the join points it
-emits as `let`s. leanprover/lean4#13305 made the new `do` elaborator the default in v4.32.0,
-and it emits `have __do_jp` join points and inlines the `if` chains instead. Pin the legacy
-elaborator here until those proofs are migrated (digama0/lean4lean#31).
--/
-set_option backward.do.legacy true
-
 namespace Lean4Lean
 open Lean hiding Environment Exception
 open Kernel

--- a/Lean4Lean/Verify/EquivManager.lean
+++ b/Lean4Lean/Verify/EquivManager.lean
@@ -266,8 +266,12 @@ theorem isEquiv.WF :
   split <;> [exact .pure nofun; skip]
   split
   · rename_i h; refine .pure ?_
-    cases e₁ <;> cases e₂ <;> simp_all [Expr.isBVar, Expr.bvarIdx!]
-    rintro rfl; exact .rfl
+    simp only [Bool.and_eq_true] at h
+    rcases h with ⟨h1, h2⟩
+    unfold Expr.isBVar at h1 h2
+    split at h1 <;> cases h1
+    split at h2 <;> cases h2
+    simp [Expr.bvarIdx!]; rintro ⟨⟩; exact .rfl
   refine toNode.WF.bind fun i₁ _ _ a1 => find.WF.bind fun j₁ _ le₁ a2 => ?_
   refine toNode.WF.bind fun i₂ _ le₂ b1 => find.WF.bind fun j₂ m₀ le₃ b2 => ?_
   refine .stateWF fun wf => ?_

--- a/Lean4Lean/Verify/EquivManager.lean
+++ b/Lean4Lean/Verify/EquivManager.lean
@@ -261,21 +261,20 @@ theorem toNode.WF :
 
 theorem isEquiv.WF :
     M.WF env Us Δ m (isEquiv useHash e₁ e₂) fun b _ => b → IsDefEqE env Us Δ e₁ e₂ := by
-  unfold isEquiv; extract_lets F1 F2 F3
+  unfold isEquiv
   split <;> [exact .pure fun _ => ptrEqExpr_eq ‹_› ▸ .rfl; skip]
-  simp [F3]; split <;> [exact .pure nofun; skip]
-  simp [F2]; split
+  split <;> [exact .pure nofun; skip]
+  split
   · rename_i h; refine .pure ?_
-    unfold Expr.isBVar at h; split at h <;> cases h.1; split at h <;> cases h.2
-    simp [Expr.bvarIdx!]; rintro ⟨⟩; exact .rfl
-  unfold F1
+    cases e₁ <;> cases e₂ <;> simp_all [Expr.isBVar, Expr.bvarIdx!]
+    rintro rfl; exact .rfl
   refine toNode.WF.bind fun i₁ _ _ a1 => find.WF.bind fun j₁ _ le₁ a2 => ?_
   refine toNode.WF.bind fun i₂ _ le₂ b1 => find.WF.bind fun j₂ m₀ le₃ b2 => ?_
   refine .stateWF fun wf => ?_
   replace a1 := le₁.trans le₂ |>.trans le₃ |>.toNodeMap a1
   replace a2 := le₂.trans le₃ |>.uf a2
   replace b1 := le₃.toNodeMap b1
-  extract_lets F4 F5
+  extract_lets F4
   split
   · rename_i h; simp at h; cases h; refine .pure fun _ => wf.defeq a1 b1 (a2.trans b2.symm)
   have {m b} (le₄ : m₀ ≤ m) (H : b = true → IsDefEqE env Us Δ e₁ e₂) :
@@ -288,7 +287,7 @@ theorem isEquiv.WF :
     have ⟨r₂, hr₂⟩ := wf.wf.1 <| b2.lt_size.1 <| wf.wf.2 ⟨_, b1⟩
     suffices IsDefEqE env Us Δ r₁ r₂ from have ⟨wf, h⟩ := merge.WF wf this hr₁ hr₂; ⟨wf, h, H⟩
     exact (wf.defeq a1 hr₁ a2).symm.trans <| .trans (H ‹_›) (wf.defeq b1 hr₂ b2)
-  simp; unfold F5; split
+  simp; split
   · apply this .rfl; simp; rintro rfl rfl; exact .rfl
   · apply this .rfl; simp; rintro rfl; exact .rfl
   · apply this .rfl; simp; rintro rfl; exact .rfl

--- a/Lean4Lean/Verify/EquivManager.lean
+++ b/Lean4Lean/Verify/EquivManager.lean
@@ -261,16 +261,11 @@ theorem toNode.WF :
 
 theorem isEquiv.WF :
     M.WF env Us Δ m (isEquiv useHash e₁ e₂) fun b _ => b → IsDefEqE env Us Δ e₁ e₂ := by
-  unfold isEquiv
-  split <;> [exact .pure fun _ => ptrEqExpr_eq ‹_› ▸ .rfl; skip]
-  split <;> [exact .pure nofun; skip]
-  split
+  unfold isEquiv; split <;> [exact .pure fun _ => ptrEqExpr_eq ‹_› ▸ .rfl; skip]
+  split <;> [exact .pure nofun; split]
   · rename_i h; refine .pure ?_
-    simp only [Bool.and_eq_true] at h
-    rcases h with ⟨h1, h2⟩
-    unfold Expr.isBVar at h1 h2
-    split at h1 <;> cases h1
-    split at h2 <;> cases h2
+    simp only [Bool.and_eq_true, Expr.isBVar] at h
+    split at h <;> cases h.1; split at h <;> cases h.2
     simp [Expr.bvarIdx!]; rintro ⟨⟩; exact .rfl
   refine toNode.WF.bind fun i₁ _ _ a1 => find.WF.bind fun j₁ _ le₁ a2 => ?_
   refine toNode.WF.bind fun i₂ _ le₂ b1 => find.WF.bind fun j₂ m₀ le₃ b2 => ?_

--- a/Lean4Lean/Verify/TypeChecker/Basic.lean
+++ b/Lean4Lean/Verify/TypeChecker/Basic.lean
@@ -917,7 +917,7 @@ theorem unfoldDefinitionCore.WF {c : VContext} {s : VState} (he : c.TrExprS e e'
     · exact (List.mapM_eq_some.1 a2).length_eq.symm.trans <| a3.trans b2.symm
   split <;> [rename_i h5; exact .pure this]
   refine .pureBind <| .get ?_
-  split <;> [rename_i eq; refine .pureBind ?_]
+  split <;> [rename_i eq; skip]
   · refine .stateWF fun wf => .pure ?_
     obtain ⟨_, _, _, ⟨⟩, a1, rfl⟩ := wf.unfold_wf eq
     cases h3.symm.trans a1; exact this

--- a/Lean4Lean/Verify/TypeChecker/InferType.lean
+++ b/Lean4Lean/Verify/TypeChecker/InferType.lean
@@ -414,7 +414,7 @@ theorem inferType'.WF
     (h1 : e.FVarsIn (· ∈ c.vlctx.fvars))
     (hinf : inferOnly = true → ∃ e', c.TrExprS e e') :
     (inferType' e inferOnly).WF c s fun ty _ => ∃ e' ty', c.TrTyping e ty e' ty' := by
-  unfold inferType'; lift_lets; intro F F1 F2 --; simp
+  unfold inferType'; lift_lets; intro F F1
   split <;> [exact .throw; refine .get <| .get ?_]
   split
   · rename_i h; refine .stateWF fun wf => .pure ?_
@@ -422,7 +422,7 @@ theorem inferType'.WF
     have : ic.WF c s := by
       subst ic; cases inferOnly <;> [exact wf.inferTypeC_wf; exact wf.inferTypeI_wf]
     exact (this h).2.2.2.2 h1
-  generalize hP : (fun ty:Expr => _) = P
+  generalize hP : (fun ty (_ : VState) => ∃ e' ty', c.TrTyping e ty e' ty') = P
   have hF {ty e' ty' s} (H : c.TrTyping e ty e' ty') : (F ty).WF c s P := by
     rintro _ mwf wf a s' ⟨⟩
     refine let s' := _; ⟨s', rfl, ?_⟩
@@ -436,7 +436,7 @@ theorem inferType'.WF
     subst P; revert s'; cases inferOnly <;> (dsimp -zeta; intro s'; refine ⟨.rfl, ?_, _, _, H⟩)
     · exact { wf with inferTypeC_wf := hic wf.inferTypeC_wf }
     · exact { wf with inferTypeI_wf := hic wf.inferTypeI_wf }
-  unfold F1; refine .get ?_; split
+  split
   · extract_lets G1; split <;> [split; skip]
     · refine .getEnv <| (M.WF.liftExcept envGet.WF).lift.bind fun _ _ _ h => ?_
       have ⟨_, h, _⟩ := c.trenv.find? h <|

--- a/Lean4Lean/Verify/TypeChecker/InferType.lean
+++ b/Lean4Lean/Verify/TypeChecker/InferType.lean
@@ -422,7 +422,7 @@ theorem inferType'.WF
     have : ic.WF c s := by
       subst ic; cases inferOnly <;> [exact wf.inferTypeC_wf; exact wf.inferTypeI_wf]
     exact (this h).2.2.2.2 h1
-  generalize hP : (fun ty (_ : VState) => ∃ e' ty', c.TrTyping e ty e' ty') = P
+  generalize hP : (fun _ (_ : VState) => _) = P
   have hF {ty e' ty' s} (H : c.TrTyping e ty e' ty') : (F ty).WF c s P := by
     rintro _ mwf wf a s' ⟨⟩
     refine let s' := _; ⟨s', rfl, ?_⟩

--- a/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
+++ b/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
@@ -316,7 +316,7 @@ theorem cacheFailure.WF {c : VContext} {s : VState} :
 theorem tryUnfoldProjApp.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
     (tryUnfoldProjApp e).WF c s fun oe _ =>
     ∀ e₁, oe = some e₁ → c.FVarsBelow e e₁ ∧ c.TrExpr e₁ e' := by
-  unfold tryUnfoldProjApp; extract_lets f F
+  unfold tryUnfoldProjApp; extract_lets f
   split <;> [exact .pure nofun; skip]
   refine (whnfCore.WF he).bind fun _ _ _ h => ?_
   refine .pure fun _ => ?_
@@ -438,8 +438,8 @@ theorem lazyDeltaReduction.loop.WF {c : VContext} {s : VState}
   unfold loop; extract_lets F1
   refine (isDefEqOffset.WF he₁ he₂).bind fun _ _ _ h => ?_; split
   · exact .pure fun hb => h (by simpa using hb)
-  suffices hF2 : ∀ {s}, (F1 ⟨⟩).WF c s fun r _ => r.WF c e₁' e₂' by
-    refine .readThe ?_; split <;> [skip; exact hF2]
+  suffices hF1 : ∀ {s}, (F1 ⟨⟩).WF c s fun r _ => r.WF c e₁' e₂' by
+    refine .readThe ?_; split <;> [skip; exact hF1]
     refine (reduceNat.WF he₁).bind fun _ _ _ h => ?_; split
     · have ⟨_, a1, a2⟩ := (h _ rfl).2
       refine (isDefEqCore.WF a1 he₂).bind fun _ _ _ h => .pure fun hb => ?_
@@ -448,7 +448,7 @@ theorem lazyDeltaReduction.loop.WF {c : VContext} {s : VState}
     · have ⟨_, a1, a2⟩ := (h _ rfl).2
       refine (isDefEqCore.WF he₁ a1).bind fun _ _ _ h => .pure fun hb => ?_
       exact (h hb).trans c.Ewf c.Δwf a2
-    exact hF2
+    exact hF1
   intro s; unfold F1; refine .getEnv ?_
   refine (M.WF.liftExcept reduceNative.WF).lift.bind fun _ _ _ h => ?_
   split <;> [cases h _ rfl; skip]
@@ -520,8 +520,8 @@ theorem isDefEqCore'.WF {c : VContext} {s : VState}
   have ⟨⟨e₁', c1, c4⟩, ⟨e₂', d1, d4⟩⟩ := h
   refine .mono (Q := fun b _ => b = true → c.IsDefEqU e₁' e₂') ?_ fun _ _ _ h hb =>
     c4.symm.trans c.Ewf c.Δwf (h (by simpa using hb)) |>.trans c.Ewf c.Δwf d4
-  extract_lets F2
-  suffices ∀ {s}, RecM.WF c s (F2 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
+  extract_lets F3
+  suffices ∀ {s}, RecM.WF c s (F3 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
     split
     · split <;> [rename_i h2; exact this]
       refine .pure fun _ => ?_
@@ -543,7 +543,7 @@ theorem isDefEqCore'.WF {c : VContext} {s : VState}
       simp at h2; subst h2; clear h
       exact .pure fun _ => c2.uniq c.Ewf (.refl c.Δwf) d2 (h ‹_›)
     · exact this
-  intro; unfold F2
+  intro; unfold F3
   refine (whnfCore.WF c1).bind fun _ _ _ ⟨_, e₁'', c5, c6⟩ => ?_
   refine (whnfCore.WF d1).bind fun _ _ _ ⟨_, e₂'', d5, d6⟩ => ?_
   split

--- a/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
+++ b/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
@@ -15,7 +15,7 @@ theorem isDefEqLambda.WF {c : VContext} {s : VState}
       b → (c.withMLC m).IsDefEqU ei₁' ei₂' := by
   unfold isDefEqLambda; let c' := c.withMLC m
   split <;> [rename_i n₁ d₁ b₁ bi₁ n₂ d₂ b₂ bi₂; (simp [hsubst]; exact isDefEq.WF he₁ he₂)]
-  extract_lets F di₁ di₂ G; unfold G di₁ di₂
+  extract_lets F di₁ di₂; unfold di₁ di₂
   simp at he₁ he₂
   let .lam (ty' := t₁') (body' := b₁') ⟨_, a1⟩ a2 a3 := he₁
   let .lam (ty' := t₂') (body' := b₂') b1 b2 b3 := he₂
@@ -85,7 +85,7 @@ theorem isDefEqForall.WF {c : VContext} {s : VState}
       b → (c.withMLC m).IsDefEqU ei₁' ei₂' := by
   unfold isDefEqForall; let c' := c.withMLC m
   split <;> [rename_i n₁ d₁ b₁ bi₁ n₂ d₂ b₂ bi₂; (simp [hsubst]; exact isDefEq.WF he₁ he₂)]
-  extract_lets F di₁ di₂ G; unfold G di₁ di₂
+  extract_lets F di₁ di₂; unfold di₁ di₂
   simp at he₁ he₂
   let .forallE (ty' := t₁') (body' := b₁') ⟨_, a1⟩ _ a2 a3 := he₁
   let .forallE (ty' := t₂') (body' := b₂') b1 ⟨_, bT⟩ b2 b3 := he₂
@@ -164,8 +164,8 @@ theorem quickIsDefEq.WF {c : VContext} {s : VState}
     · intro h; apply (VEnv.IsDefEqU.weak'_iff c.Ewf a1 a2.toCtx).1
       exact (h1 h).uniq c.Ewf (a2.bvars_eq.trans c.mlctx.noBV)
         a1 (he₁.weakFV' c.Ewf a2 a1) (he₂.weakFV' c.Ewf a2 a1)
-  extract_lets F; split <;> [exact .pure fun _ => h ‹_›; skip]
-  refine .pureBind ?_; unfold F; split
+  split <;> [exact .pure fun _ => h ‹_›; skip]
+  split
   · exact .toLBoolM <| c.withMLC_self ▸
       isDefEqLambda.WF (subst := #[]) (fvs := []) rfl (c.withMLC_self ▸ he₁) (c.withMLC_self ▸ he₂)
   · exact .toLBoolM <| c.withMLC_self ▸
@@ -238,14 +238,14 @@ theorem tryEtaStruct.WF {c : VContext} {s : VState}
 theorem isDefEqApp.WF {c : VContext} {s : VState}
     (he₁ : c.TrExprS e₁ e₁') (he₂ : c.TrExprS e₂ e₂') :
     RecM.WF c s (isDefEqApp e₁ e₂) fun b _ => b → c.IsDefEqU e₁' e₂' := by
-  unfold isDefEqApp; extract_lets F1
-  split <;> [(refine .pureBind ?_; unfold F1); exact .pure nofun]
+  unfold isDefEqApp
+  split <;> [skip; exact .pure nofun]
   rw [Expr.withApp_eq, Expr.withApp_eq]
   split <;> [rename_i eq; exact .pure nofun]
   have ⟨_, he₁'⟩ := AppStack.build <| e₁.mkAppList_getAppArgsList ▸ he₁
   have ⟨_, he₂'⟩ := AppStack.build <| e₂.mkAppList_getAppArgsList ▸ he₂
-  refine (isDefEq.WF he₁'.tr he₂'.tr).bind fun _ _ _ h => ?_; extract_lets F2
-  split <;> [(refine .pureBind ?_; unfold F2); exact .pure nofun]
+  refine (isDefEq.WF he₁'.tr he₂'.tr).bind fun _ _ _ h => ?_
+  split <;> [skip; exact .pure nofun]
   let rec loop.WF {s args₁ args₂ f₁ f₂ f₁' f₂' eq i} (l₁ r₁ l₂ r₂)
       (h₁ : args₁.toList = l₁ ++ r₁) (hi₁ : l₁.length = i)
       (h₂ : args₂.toList = l₂ ++ r₂) (hi₂ : l₂.length = i)
@@ -300,9 +300,9 @@ theorem isDefEqProofIrrel.WF {c : VContext} {s : VState}
     (he₁ : c.TrExprS e₁ e₁') (he₂ : c.TrExprS e₂ e₂') :
     RecM.WF c s (isDefEqProofIrrel e₁ e₂) fun b _ => b = .true → c.IsDefEqU e₁' e₂' := by
   unfold isDefEqProofIrrel
-  refine (inferType.WF he₁).bind fun _ _ _ ⟨_, a1, a2, a3, a4⟩ => ?_; extract_lets F1
+  refine (inferType.WF he₁).bind fun _ _ _ ⟨_, a1, a2, a3, a4⟩ => ?_
   refine (isProp.WF a3).bind fun _ _ _ h1 => ?_
-  split <;> [exact .pure nofun; (refine .pureBind ?_; unfold F1)]
+  split <;> [exact .pure nofun; skip]
   rename_i h; simp at h
   refine (inferType.WF he₂).bind fun _ _ _ ⟨_, b1, b2, b3, b4⟩ => .toLBoolM ?_
   refine (isDefEq.WF a3 b3).mono fun _ _ _ h2 hb => ?_
@@ -318,7 +318,6 @@ theorem tryUnfoldProjApp.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
     ∀ e₁, oe = some e₁ → c.FVarsBelow e e₁ ∧ c.TrExpr e₁ e' := by
   unfold tryUnfoldProjApp; extract_lets f F
   split <;> [exact .pure nofun; skip]
-  refine .pureBind ?_; unfold F
   refine (whnfCore.WF he).bind fun _ _ _ h => ?_
   refine .pure fun _ => ?_
   split <;> rintro ⟨⟩; exact h
@@ -420,11 +419,11 @@ theorem isNatSuccOf?_wf {c : VContext} (H : isNatSuccOf? e = some e₁)
 theorem isDefEqOffset.WF {c : VContext} {s : VState}
     (he₁ : c.TrExprS e₁ e₁') (he₂ : c.TrExprS e₂ e₂') :
     (isDefEqOffset e₁ e₂).WF c s fun b _ => b = .true → c.IsDefEqU e₁' e₂' := by
-  unfold isDefEqOffset; extract_lets F; split
+  unfold isDefEqOffset; split
   · rename_i h; simp at h
     cases isNatZero_wf h.1 he₁; cases isNatZero_wf h.2 he₂
     exact .pure fun _ => .refl <| he₁.wf c.Ewf c.Δwf
-  · refine .pureBind ?_; unfold F; split <;> [skip; exact .pure nofun]
+  · split <;> [skip; exact .pure nofun]
     obtain ⟨_, a1, rfl⟩ := isNatSuccOf?_wf ‹_› he₁
     obtain ⟨_, b1, rfl⟩ := isNatSuccOf?_wf ‹_› he₂
     refine .toLBoolM <| (isDefEqCore.WF a1 b1).mono fun _ _ _ h hb => ?_
@@ -436,11 +435,11 @@ theorem lazyDeltaReduction.loop.WF {c : VContext} {s : VState}
     (he₁ : c.TrExprS e₁ e₁') (he₂ : c.TrExprS e₂ e₂') :
     (lazyDeltaReduction.loop e₁ e₂ n).WF c s fun r _ => r.WF c e₁' e₂' := by
   induction n generalizing s e₁ e₂ e₁' e₂' with | zero => exact .throw | succ n ih
-  unfold loop; extract_lets F1 F2 F3
+  unfold loop; extract_lets F1
   refine (isDefEqOffset.WF he₁ he₂).bind fun _ _ _ h => ?_; split
   · exact .pure fun hb => h (by simpa using hb)
-  suffices hF2 : ∀ {s}, (F2 ⟨⟩).WF c s fun r _ => r.WF c e₁' e₂' by
-    refine .pureBind <|.readThe ?_; split <;> [skip; exact hF2]
+  suffices hF2 : ∀ {s}, (F1 ⟨⟩).WF c s fun r _ => r.WF c e₁' e₂' by
+    refine .readThe ?_; split <;> [skip; exact hF2]
     refine (reduceNat.WF he₁).bind fun _ _ _ h => ?_; split
     · have ⟨_, a1, a2⟩ := (h _ rfl).2
       refine (isDefEqCore.WF a1 he₂).bind fun _ _ _ h => .pure fun hb => ?_
@@ -450,12 +449,11 @@ theorem lazyDeltaReduction.loop.WF {c : VContext} {s : VState}
       refine (isDefEqCore.WF he₁ a1).bind fun _ _ _ h => .pure fun hb => ?_
       exact (h hb).trans c.Ewf c.Δwf a2
     exact hF2
-  intro s; unfold F2; refine .getEnv ?_
+  intro s; unfold F1; refine .getEnv ?_
   refine (M.WF.liftExcept reduceNative.WF).lift.bind fun _ _ _ h => ?_
   split <;> [cases h _ rfl; skip]
   refine (M.WF.liftExcept reduceNative.WF).lift.bind fun _ _ _ h => ?_
   split <;> [cases h _ rfl; skip]
-  refine .pureBind ?_; unfold F1
   refine (lazyDeltaReductionStep.WF he₁ he₂).bind fun r _ _ h => ?_
   obtain r|r|r := r
   · let ⟨_, ⟨_, a1, a2⟩, ⟨_, b1, b2⟩⟩ := h
@@ -484,11 +482,11 @@ theorem isDefEqUnitLike.WF {c : VContext} {s : VState}
 theorem isDefEqCore'.WF {c : VContext} {s : VState}
     (he₁ : c.TrExprS e₁ e₁') (he₂ : c.TrExprS e₂ e₂') :
     RecM.WF c s (isDefEqCore' e₁ e₂) fun b _ => b = true → c.IsDefEqU e₁' e₂' := by
-  unfold isDefEqCore'; extract_lets F1 F2 F3
+  unfold isDefEqCore'; extract_lets F1
   refine (quickIsDefEq.WF he₁ he₂).bind fun _ _ _ h => ?_
   split <;> [exact .pure fun hb => h (by simpa using hb); skip]
-  refine .pureBind <| .readThe ?_
-  suffices ∀ {s}, RecM.WF c s (F2 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
+  refine .readThe ?_
+  suffices ∀ {s}, RecM.WF c s (F1 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
     split <;> [rename_i h1; exact this]
     refine (whnf.WF he₁).bind fun _ _ _ ⟨_, _, a1, a2⟩ => ?_
     split <;> [rename_i h2; exact this]
@@ -501,29 +499,29 @@ theorem isDefEqCore'.WF {c : VContext} {s : VState}
     cases c.hasPrimitives.boolTrue c1
     simp at b3 c3; subst b3 c3; simp at b2 c2; subst b2 c2
     exact a2.symm
-  intro; unfold F2
+  intro; unfold F1
   refine (whnfCore.WF he₁).bind fun _ _ _ ⟨_, e₁', a1, a2⟩ => ?_
   refine (whnfCore.WF he₂).bind fun _ _ _ ⟨_, e₂', b1, b2⟩ => ?_
-  extract_lets F2 F3
+  extract_lets F2
   refine .mono (Q := fun b _ => b = true → c.IsDefEqU e₁' e₂') ?_ fun _ _ _ h hb =>
     a2.symm.trans c.Ewf c.Δwf (h (by simpa using hb)) |>.trans c.Ewf c.Δwf b2
-  suffices ∀ {s}, RecM.WF c s (F3 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
+  suffices ∀ {s}, RecM.WF c s (F2 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
     split <;> [skip; exact this]
     refine (quickIsDefEq.WF a1 b1).bind fun _ _ _ h => ?_
     split <;> [skip; exact this]
     exact .pure fun hb => h (by simpa using hb)
-  intro; unfold F3
+  intro; unfold F2
   refine (isDefEqProofIrrel.WF a1 b1).bind fun _ _ _ h => ?_
   split
   · exact .pure fun hb => h (by simpa using hb)
-  refine .pureBind <| (lazyDeltaReduction.loop.WF a1 b1).readThe.bind fun _ _ _ h => ?_; split
+  refine (lazyDeltaReduction.loop.WF a1 b1).readThe.bind fun _ _ _ h => ?_; split
   · cases h.1
   · exact .pure h
   have ⟨⟨e₁', c1, c4⟩, ⟨e₂', d1, d4⟩⟩ := h
   refine .mono (Q := fun b _ => b = true → c.IsDefEqU e₁' e₂') ?_ fun _ _ _ h hb =>
     c4.symm.trans c.Ewf c.Δwf (h (by simpa using hb)) |>.trans c.Ewf c.Δwf d4
-  extract_lets F2 F3 F4 F5 F6 F7
-  suffices ∀ {s}, RecM.WF c s (F7 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
+  extract_lets F2
+  suffices ∀ {s}, RecM.WF c s (F2 ⟨⟩) fun b _ => b = true → c.IsDefEqU e₁' e₂' by
     split
     · split <;> [rename_i h2; exact this]
       refine .pure fun _ => ?_
@@ -545,20 +543,20 @@ theorem isDefEqCore'.WF {c : VContext} {s : VState}
       simp at h2; subst h2; clear h
       exact .pure fun _ => c2.uniq c.Ewf (.refl c.Δwf) d2 (h ‹_›)
     · exact this
-  intro; unfold F7
+  intro; unfold F2
   refine (whnfCore.WF c1).bind fun _ _ _ ⟨_, e₁'', c5, c6⟩ => ?_
   refine (whnfCore.WF d1).bind fun _ _ _ ⟨_, e₂'', d5, d6⟩ => ?_
   split
-  · exact (isDefEqCore.WF c5 d5).bind fun _ _ _ h => .pure fun hb =>
+  · exact (isDefEqCore.WF c5 d5).mono fun _ _ _ h hb =>
       c6.symm.trans c.Ewf c.Δwf (h (by simpa using hb)) |>.trans c.Ewf c.Δwf d6
-  refine .pureBind <| (isDefEqApp.WF c1 d1).bind fun _ _ _ h => ?_
+  refine (isDefEqApp.WF c1 d1).bind fun _ _ _ h => ?_
   split <;> [exact .pure fun _ => h ‹_›; skip]
-  refine .pureBind <| (tryEtaExpansion.WF c1 d1).bind fun _ _ _ h => ?_
+  refine (tryEtaExpansion.WF c1 d1).bind fun _ _ _ h => ?_
   split <;> [exact .pure fun _ => h ‹_›; skip]
-  refine .pureBind <| (tryEtaStruct.WF c1 d1).bind fun _ _ _ h => ?_
+  refine (tryEtaStruct.WF c1 d1).bind fun _ _ _ h => ?_
   split <;> [exact .pure fun _ => h ‹_›; skip]
-  refine .pureBind <| (tryStringLitExpansion.WF c1 d1).bind fun _ _ _ h => ?_
+  refine (tryStringLitExpansion.WF c1 d1).bind fun _ _ _ h => ?_
   split <;> [exact .pure fun hb => h (by simpa using hb); skip]
-  refine .pureBind <| (isDefEqUnitLike.WF c1 d1).bind fun _ _ _ h => ?_
+  refine (isDefEqUnitLike.WF c1 d1).bind fun _ _ _ h => ?_
   split <;> [exact .pure fun _ => h ‹_›; skip]
-  exact .pureBind <| .pure nofun
+  exact .pure nofun

--- a/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
+++ b/Lean4Lean/Verify/TypeChecker/IsDefEq.lean
@@ -164,8 +164,7 @@ theorem quickIsDefEq.WF {c : VContext} {s : VState}
     · intro h; apply (VEnv.IsDefEqU.weak'_iff c.Ewf a1 a2.toCtx).1
       exact (h1 h).uniq c.Ewf (a2.bvars_eq.trans c.mlctx.noBV)
         a1 (he₁.weakFV' c.Ewf a2 a1) (he₂.weakFV' c.Ewf a2 a1)
-  split <;> [exact .pure fun _ => h ‹_›; skip]
-  split
+  split <;> [exact .pure fun _ => h ‹_›; split]
   · exact .toLBoolM <| c.withMLC_self ▸
       isDefEqLambda.WF (subst := #[]) (fvs := []) rfl (c.withMLC_self ▸ he₁) (c.withMLC_self ▸ he₂)
   · exact .toLBoolM <| c.withMLC_self ▸
@@ -238,8 +237,7 @@ theorem tryEtaStruct.WF {c : VContext} {s : VState}
 theorem isDefEqApp.WF {c : VContext} {s : VState}
     (he₁ : c.TrExprS e₁ e₁') (he₂ : c.TrExprS e₂ e₂') :
     RecM.WF c s (isDefEqApp e₁ e₂) fun b _ => b → c.IsDefEqU e₁' e₂' := by
-  unfold isDefEqApp
-  split <;> [skip; exact .pure nofun]
+  unfold isDefEqApp; split <;> [skip; exact .pure nofun]
   rw [Expr.withApp_eq, Expr.withApp_eq]
   split <;> [rename_i eq; exact .pure nofun]
   have ⟨_, he₁'⟩ := AppStack.build <| e₁.mkAppList_getAppArgsList ▸ he₁

--- a/Lean4Lean/Verify/TypeChecker/Reduce.lean
+++ b/Lean4Lean/Verify/TypeChecker/Reduce.lean
@@ -93,31 +93,10 @@ theorem reduceNat.WF {c : VContext} (he : c.TrExprS e e') :
   refine let prims := _; have hprims : Environment.primitives = .ofList prims := rfl; ?_
   replace hprims {a} : Environment.primitives.contains a ↔ a ∈ prims := by
     simp [hprims, NameSet.contains, NameSet.ofList]
-  unfold reduceNat
-  by_cases hnargs1 : e.getAppNumArgs = 1
-  · rw [if_pos (by simpa using hnargs1)]
-    by_cases hsucc : (e.appFn! == .const ``Nat.succ []) = true
-    · rw [if_pos hsucc]
-      simp [Expr.getAppNumArgs_eq] at hnargs1
-      let .app f a := e; simp [Expr.appFn!, Expr.eqv_const] at hsucc ⊢; subst f
-      let .app ha1 ha2 hf ha := he
-      let .const h1 h2 h3 := hf
-      refine (whnf.WF ha).bind fun a₁ _ _ ⟨a1, _, a2, a3⟩ => ?_
-      split <;> [rename_i n h; exact hP ▸ .pure nofun]
-      obtain ⟨hn, rfl⟩ := rawNatLitExt?.WF h a2
-      refine hP ▸ .pure ?_; rintro _ ⟨⟩; refine ⟨fun _ _ _ => trivial, ?_⟩
-      have ⟨ci, c1, _⟩ := c.trenv.find?_iff.2 ⟨_, h1⟩
-      have ⟨c2, c3⟩ := c.safePrimitives c1 <| hprims.2 (by simp [prims])
-      have ⟨d1, d2, d3⟩ := c.trenv.find?_uniq c1 h1; cases h2
-      refine have ⟨p1, p2⟩ := TrExprS.natLit c.hasPrimitives hn _; ⟨_, p1, ?_⟩
-      refine p2.toU.symm.trans c.Ewf c.Δwf ?_
-      exact ⟨_, ha1.appDF <| a3.of_r c.Ewf c.Δwf ha2⟩
-    · rw [if_neg hsucc]; exact hP ▸ .pure nofun
-  rw [if_neg (by simpa using hnargs1)]
-  by_cases hnargs2 : e.getAppNumArgs = 2
-  · rw [if_pos (by simpa using hnargs2)]
-    split <;> [skip; exact hP ▸ .pure nofun]
-    rename_i f ls a b
+  unfold reduceNat; extract_lets nargs F1 fn
+  cases h1 : nargs == 1 <;> simp only [Bool.false_eq_true, ↓reduceIte]
+  · cases nargs == 2 <;> [exact hP ▸ .pure nofun; simp only [↓reduceIte]]
+    split <;> [rename_i f ls a b; exact hP ▸ .pure nofun]
     have hfun guard {g fc G} [DecidableRel guard] (hprim : fc ∈ prims)
         (heval : c.venv.ReflectsNatNatNat fc g) (hG : RecM.WF c s G P) :
         RecM.WF c s (do if f == fc then {return ← reduceBinNatOpG guard g a b}; G) P := by
@@ -145,4 +124,18 @@ theorem reduceNat.WF {c : VContext} (he : c.TrExprS e e') :
     apply hfun (fun _ _ => False) (by simp [prims]) c.hasPrimitives.natShiftLeft
     apply hfun (fun _ _ => False) (by simp [prims]) c.hasPrimitives.natShiftRight
     exact hP ▸ .pure nofun
-  · rw [if_neg (by simpa using hnargs2)]; exact hP ▸ .pure nofun
+  · split <;> [rename_i h2; exact hP ▸ .pure nofun]
+    simp [nargs, Expr.getAppNumArgs_eq] at h1; subst fn
+    let .app f a := e; simp [Expr.appFn!, Expr.eqv_const] at h2 ⊢; subst h2
+    let .app ha1 ha2 hf ha := he
+    let .const h1 h2 h3 := hf
+    refine (whnf.WF ha).bind fun a₁ _ _ ⟨a1, _, a2, a3⟩ => ?_
+    split <;> [rename_i n h; exact hP ▸ .pure nofun]
+    obtain ⟨hn, rfl⟩ := rawNatLitExt?.WF h a2
+    refine hP ▸ .pure ?_; rintro _ ⟨⟩; refine ⟨fun _ _ _ => trivial, ?_⟩
+    have ⟨ci, c1, _⟩ := c.trenv.find?_iff.2 ⟨_, h1⟩
+    have ⟨c2, c3⟩ := c.safePrimitives c1 <| hprims.2 (by simp [prims])
+    have ⟨d1, d2, d3⟩ := c.trenv.find?_uniq c1 h1; cases h2
+    refine have ⟨p1, p2⟩ := TrExprS.natLit c.hasPrimitives hn _; ⟨_, p1, ?_⟩
+    refine p2.toU.symm.trans c.Ewf c.Δwf ?_
+    exact ⟨_, ha1.appDF <| a3.of_r c.Ewf c.Δwf ha2⟩

--- a/Lean4Lean/Verify/TypeChecker/Reduce.lean
+++ b/Lean4Lean/Verify/TypeChecker/Reduce.lean
@@ -1,13 +1,5 @@
 import Lean4Lean.Verify.TypeChecker.Basic
 
-/-
-This file states `RecM.WF` goals with `do` blocks that have to match the shape the
-definitions in `Lean4Lean.TypeChecker` elaborate to, which is pinned to the legacy `do`
-elaborator (leanprover/lean4#13305). Pin it here too so the two agree
-(digama0/lean4lean#31).
--/
-set_option backward.do.legacy true
-
 namespace Lean4Lean.TypeChecker.Inner
 open Lean hiding Environment Exception
 open Kernel
@@ -101,24 +93,31 @@ theorem reduceNat.WF {c : VContext} (he : c.TrExprS e e') :
   refine let prims := _; have hprims : Environment.primitives = .ofList prims := rfl; ?_
   replace hprims {a} : Environment.primitives.contains a ↔ a ∈ prims := by
     simp [hprims, NameSet.contains, NameSet.ofList]
-  unfold reduceNat; extract_lets nargs F1 fn
-  split <;> (split <;> [skip; exact hP ▸ .pure nofun])
-  · rename_i h1 h2
-    simp [nargs, Expr.getAppNumArgs_eq] at h1; subst fn
-    let .app f a := e; simp [Expr.appFn!, Expr.eqv_const] at h2 ⊢; subst h2
-    let .app ha1 ha2 hf ha := he
-    let .const h1 h2 h3 := hf
-    refine (whnf.WF ha).bind fun a₁ _ _ ⟨a1, _, a2, a3⟩ => ?_
-    split <;> [rename_i n h; exact hP ▸ .pure nofun]
-    obtain ⟨hn, rfl⟩ := rawNatLitExt?.WF h a2
-    refine hP ▸ .pure ?_; rintro _ ⟨⟩; refine ⟨fun _ _ _ => trivial, ?_⟩
-    have ⟨ci, c1, _⟩ := c.trenv.find?_iff.2 ⟨_, h1⟩
-    have ⟨c2, c3⟩ := c.safePrimitives c1 <| hprims.2 (by simp [prims])
-    have ⟨d1, d2, d3⟩ := c.trenv.find?_uniq c1 h1; cases h2
-    refine have ⟨p1, p2⟩ := TrExprS.natLit c.hasPrimitives hn _; ⟨_, p1, ?_⟩
-    refine p2.toU.symm.trans c.Ewf c.Δwf ?_
-    exact ⟨_, ha1.appDF <| a3.of_r c.Ewf c.Δwf ha2⟩
-  · split <;> [rename_i f ls a b _ h2; exact hP ▸ .pure nofun]
+  unfold reduceNat
+  by_cases hnargs1 : e.getAppNumArgs = 1
+  · rw [if_pos (by simpa using hnargs1)]
+    by_cases hsucc : (e.appFn! == .const ``Nat.succ []) = true
+    · rw [if_pos hsucc]
+      simp [Expr.getAppNumArgs_eq] at hnargs1
+      let .app f a := e; simp [Expr.appFn!, Expr.eqv_const] at hsucc ⊢; subst f
+      let .app ha1 ha2 hf ha := he
+      let .const h1 h2 h3 := hf
+      refine (whnf.WF ha).bind fun a₁ _ _ ⟨a1, _, a2, a3⟩ => ?_
+      split <;> [rename_i n h; exact hP ▸ .pure nofun]
+      obtain ⟨hn, rfl⟩ := rawNatLitExt?.WF h a2
+      refine hP ▸ .pure ?_; rintro _ ⟨⟩; refine ⟨fun _ _ _ => trivial, ?_⟩
+      have ⟨ci, c1, _⟩ := c.trenv.find?_iff.2 ⟨_, h1⟩
+      have ⟨c2, c3⟩ := c.safePrimitives c1 <| hprims.2 (by simp [prims])
+      have ⟨d1, d2, d3⟩ := c.trenv.find?_uniq c1 h1; cases h2
+      refine have ⟨p1, p2⟩ := TrExprS.natLit c.hasPrimitives hn _; ⟨_, p1, ?_⟩
+      refine p2.toU.symm.trans c.Ewf c.Δwf ?_
+      exact ⟨_, ha1.appDF <| a3.of_r c.Ewf c.Δwf ha2⟩
+    · rw [if_neg hsucc]; exact hP ▸ .pure nofun
+  rw [if_neg (by simpa using hnargs1)]
+  by_cases hnargs2 : e.getAppNumArgs = 2
+  · rw [if_pos (by simpa using hnargs2)]
+    split <;> [skip; exact hP ▸ .pure nofun]
+    rename_i f ls a b
     have hfun guard {g fc G} [DecidableRel guard] (hprim : fc ∈ prims)
         (heval : c.venv.ReflectsNatNatNat fc g) (hG : RecM.WF c s G P) :
         RecM.WF c s (do if f == fc then {return ← reduceBinNatOpG guard g a b}; G) P := by
@@ -146,3 +145,4 @@ theorem reduceNat.WF {c : VContext} (he : c.TrExprS e e') :
     apply hfun (fun _ _ => False) (by simp [prims]) c.hasPrimitives.natShiftLeft
     apply hfun (fun _ _ => False) (by simp [prims]) c.hasPrimitives.natShiftRight
     exact hP ▸ .pure nofun
+  · rw [if_neg (by simpa using hnargs2)]; exact hP ▸ .pure nofun

--- a/Lean4Lean/Verify/TypeChecker/WHNF.lean
+++ b/Lean4Lean/Verify/TypeChecker/WHNF.lean
@@ -33,13 +33,13 @@ theorem whnfCore'.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
   let full := (· matches Expr.fvar _ | .app .. | .letE .. | .proj ..)
   generalize hP : (fun e₁ (_ : VState) => _) = P
   have hid {s} : RecM.WF c s (pure e) P := hP ▸ .pure ⟨.rfl, he.trExpr c.Ewf c.Δwf⟩
-  suffices hG : full e → RecM.WF c s (F ⟨⟩) P by
+  suffices hF : full e → RecM.WF c s (F ⟨⟩) P by
     split
     any_goals exact hid
-    any_goals exact hG rfl
+    any_goals exact hF rfl
     · let .mdata he := he
       exact hP ▸ whnfCore'.WF he
-    · refine .getLCtx ?_; split <;> [exact hid; exact hG rfl]
+    · refine .getLCtx ?_; split <;> [exact hid; exact hF rfl]
   simp [F]; refine fun hfull => .get ?_; split
   · rename_i r eq; refine .stateWF fun wf => hP ▸ .pure ?_
     have ⟨_, h1, h2, h3⟩ := (wf.whnfCore_wf eq).2.2.2.2 he.fvarsIn
@@ -134,13 +134,13 @@ theorem whnf'.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
   unfold whnf'; extract_lets F
   generalize hP : (fun e₁ (_ : VState) => _) = P
   have hid {s} : RecM.WF c s (pure e) P := hP ▸ .pure ⟨.rfl, he.trExpr c.Ewf c.Δwf⟩
-  suffices hG : RecM.WF c s (F ()) P by
+  suffices hF : RecM.WF c s (F ()) P by
     split
     any_goals exact hid
-    any_goals exact hG
+    any_goals exact hF
     · let .mdata he := he
       exact hP ▸ whnf'.WF he
-    · refine .getLCtx ?_; split <;> [exact hid; exact hG]
+    · refine .getLCtx ?_; split <;> [exact hid; exact hF]
   simp [F]; refine .get ?_; split
   · rename_i r eq; refine .stateWF fun wf => hP ▸ .pure ?_
     have ⟨_, h1, h2, h3⟩ := (wf.whnf_wf eq).2.2.2.2 he.fvarsIn

--- a/Lean4Lean/Verify/TypeChecker/WHNF.lean
+++ b/Lean4Lean/Verify/TypeChecker/WHNF.lean
@@ -29,18 +29,18 @@ theorem reduceProj.WF {c : VContext} {s : VState} (he : c.TrExprS (.proj n i e) 
 theorem whnfCore'.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
     RecM.WF c s (whnfCore' e cheapRec cheapProj) fun e₁ _ =>
       c.FVarsBelow e e₁ ∧ c.TrExpr e₁ e' := by
-  unfold whnfCore'; extract_lets F G
+  unfold whnfCore'; extract_lets F
   let full := (· matches Expr.fvar _ | .app .. | .letE .. | .proj ..)
   generalize hP : (fun e₁ (_ : VState) => _) = P
   have hid {s} : RecM.WF c s (pure e) P := hP ▸ .pure ⟨.rfl, he.trExpr c.Ewf c.Δwf⟩
-  suffices hG : full e → RecM.WF c s (G ⟨⟩) P by
+  suffices hG : full e → RecM.WF c s (F ⟨⟩) P by
     split
     any_goals exact hid
     any_goals exact hG rfl
     · let .mdata he := he
-      exact (whnfCore'.WF he).bind fun _ _ _ h => hP ▸ .pure h
+      exact hP ▸ whnfCore'.WF he
     · refine .getLCtx ?_; split <;> [exact hid; exact hG rfl]
-  simp [G]; refine fun hfull => .get ?_; split
+  simp [F]; refine fun hfull => .get ?_; split
   · rename_i r eq; refine .stateWF fun wf => hP ▸ .pure ?_
     have ⟨_, h1, h2, h3⟩ := (wf.whnfCore_wf eq).2.2.2.2 he.fvarsIn
     refine ⟨h1, h3.defeq c.Ewf c.Δwf ?_⟩
@@ -59,10 +59,9 @@ theorem whnfCore'.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
       · exact he.fvarsIn.mono wf.ngen_wf
       · exact h2.fvarsIn.mono wf.ngen_wf
     exact hP ▸ ⟨.rfl, { wf with whnfCore_wf := hic wf.whnfCore_wf }, h1, h2⟩
-  unfold F; split <;> cases hfull
-  · simp; exact hP ▸ whnfFVar.WF he
+  split <;> cases hfull
+  · exact hP ▸ whnfFVar.WF he
   · rename_i fn arg _; generalize eq : fn.app arg = e at *
-    rw [Expr.withRevApp_eq]
     have ⟨_, stk⟩ := AppStack.build <| e.mkAppList_getAppArgsList ▸ he
     refine (whnfCore.WF stk.tr).bind fun _ s _ ⟨h1, h2⟩ => ?_
     split <;> [rename_i name dom body bi _; split]
@@ -120,7 +119,7 @@ theorem whnfCore'.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
       let ⟨h3, _, h4, eq⟩ := eq ▸ this h1 (eq ▸ he) stk.tr h2
       refine (whnfCore.WF h4).bind fun _ _ _ ⟨h5, h6⟩ => ?_
       refine hsave (h3.trans h5) (h6.defeq c.Ewf c.Δwf eq)
-  · let .letE h1 h2 h3 h4 := he; simp
+  · let .letE h1 h2 h3 h4 := he
     refine (whnfCore.WF (h4.inst_let c.Ewf.ordered h3)).bind fun _ _ _ ⟨h1, h2⟩ => ?_
     exact hsave (.trans (fun _ _ he => he.2.2.instantiate1 he.2.1) h1) h2
   · refine (reduceProj.WF he).bind fun _ _ _ H => ?_
@@ -132,32 +131,29 @@ theorem whnfCore'.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
 
 theorem whnf'.WF {c : VContext} {s : VState} (he : c.TrExprS e e') :
     RecM.WF c s (whnf' e) fun e₁ _ => c.FVarsBelow e e₁ ∧ c.TrExpr e₁ e' := by
-  unfold whnf'; extract_lets F G
+  unfold whnf'; extract_lets F
   generalize hP : (fun e₁ (_ : VState) => _) = P
   have hid {s} : RecM.WF c s (pure e) P := hP ▸ .pure ⟨.rfl, he.trExpr c.Ewf c.Δwf⟩
-  suffices hG : RecM.WF c s (G ()) P by
+  suffices hG : RecM.WF c s (F ()) P by
     split
     any_goals exact hid
     any_goals exact hG
     · let .mdata he := he
-      exact (whnf'.WF he).bind fun _ _ _ h => hP ▸ .pure h
+      exact hP ▸ whnf'.WF he
     · refine .getLCtx ?_; split <;> [exact hid; exact hG]
-  simp [G]; refine .get ?_; split
+  simp [F]; refine .get ?_; split
   · rename_i r eq; refine .stateWF fun wf => hP ▸ .pure ?_
     have ⟨_, h1, h2, h3⟩ := (wf.whnf_wf eq).2.2.2.2 he.fvarsIn
     refine ⟨h1, h3.defeq c.Ewf c.Δwf ?_⟩
     exact h2.uniq c.Ewf (.refl c.Ewf c.Δwf) he
-  unfold F
   have {e e' s n} (he : c.TrExprS e e') : (loop e n).WF c s fun e₁ _ =>
       c.FVarsBelow e e₁ ∧ c.TrExpr e₁ e' := by
     induction n generalizing s e e' with | zero => exact .throw | succ n ih => ?_
     refine .getEnv <| (whnfCore'.WF he).bind fun e₁ s _ ⟨h1, _, he₁, eq⟩ => ?_
     refine (M.WF.liftExcept reduceNative.WF).lift.bind fun _ _ _ h3 => ?_
-    extract_lets F1 F2; split <;> [cases h3 _ rfl; skip]
-    refine .pureBind ?_; unfold F2
+    split <;> [cases h3 _ rfl; skip]
     refine (reduceNat.WF he₁).bind fun _ _ _ h3 => ?_; split
     · exact .pure ⟨.trans h1 (h3 _ rfl).1, (h3 _ rfl).2.defeq c.Ewf c.Δwf eq⟩
-    refine .pureBind ?_; unfold F1
     refine (unfoldDefinition.WF he₁).bind fun _ _ _ H => ?_
     split <;> [skip; exact .pure ⟨h1, _, he₁, eq⟩]
     have ⟨a1, _, a2, eq'⟩ := H


### PR DESCRIPTION
Follows #30 and is rebased onto its merged result.

Advances #31. The independent `Experimental/ShapeLogRel.lean` migration remains pinned to the legacy elaborator and is deliberately left for separate work.

## Summary

- remove the three `backward.do.legacy` compatibility pins covering `TypeChecker`, `EquivManager`, and `Verify/TypeChecker/Reduce`
- migrate the verifier proofs to the new `do` elaborator
- leave `Experimental/ShapeLogRel.lean` unchanged to avoid proof-quality regressions and conflicts with ongoing work

## Verification

- `lake build`
- `lake build Lean4Lean.Experimental`
- `lake exe lean4lean Init.Core`
- `lake exe lean4lean --fresh Init.System.IO`

## Coverage note

Removing the `TypeChecker.lean` pin changes elaborated terms in code paths whose existing `.WF` theorems still contain `sorry` (`reduceRecursor`, `reduceProj`, `inferProj`, `tryEtaStructCore`, and `isDefEqUnitLike`). The fresh `Init.System.IO` replay is therefore part of the safety check, rather than relying only on proof coverage.