### PR TITLE
ci: add Zulip emoji reconcile workflow

### DIFF
--- a/.github/workflows/zulip_emoji_reconcile.yml
+++ b/.github/workflows/zulip_emoji_reconcile.yml
@@ -1,0 +1,90 @@
+name: Zulip emoji reconcile
+
+on:
+  schedule:
+    - cron: "37 * * * *"   # hourly sweep: the self-healing safety net
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number(s), space-separated; leave empty to sweep recent messages"
+        required: false
+        default: ""
+      dry-run:
+        description: "Log planned reaction changes without writing to Zulip"
+        type: boolean
+        default: false
+  pull_request_target:      # close/merge/reopen changes, within seconds
+    types: [closed, reopened]
+  workflow_run:             # CI start/finish, so the CI emoji updates promptly
+    workflows: ["CI"]
+    types: [requested, completed]
+
+concurrency:
+  # Serialize runs: the reconciler reads live PR state and then writes
+  # reactions, so two interleaved runs could re-assert stale state. GitHub
+  # keeps only the newest queued run per group (earlier pending runs are
+  # canceled), which suits a level-triggered tool — the last run recomputes
+  # everything from live state and converges to the final answer.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    if: github.repository == 'digama0/lean4lean'   # skip runs on forks
+    steps:
+      # On pull_request_target / workflow_run this checks out the *default*
+      # branch, so the config (and everything else that runs in this job) is
+      # never PR-controlled.
+      - name: Check out this repo's config
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/zulip-emoji-config.json
+          sparse-checkout-cone-mode: false
+
+      - name: Determine PR number(s)
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          case "$EVENT" in
+            workflow_dispatch) pr="$INPUT_PR" ;;
+            pull_request_target) pr="$EVENT_PR" ;;
+            workflow_run)
+              # PR(s) at the CI run's head commit (works for fork PRs too).
+              pr=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+                     --jq 'map(.number) | join(" ")')
+              ;;
+            *) pr="" ;;  # schedule -> sweep
+          esac
+          echo "pr=${pr}" >> "$GITHUB_OUTPUT"
+
+      - name: Reconcile
+        # Skip only a workflow_run whose head commit no longer maps to a PR;
+        # schedule and PR-less dispatches sweep instead.
+        if: steps.target.outputs.pr != '' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: leanprover-community/mathlib-ci/.github/actions/zulip-emoji-reconcile@5668fbbccf0fecefdfcddf539b8406db197dfc59
+        with:
+          config: .github/zulip-emoji-config.json
+          pr: ${{ steps.target.outputs.pr }}
+          sweep: ${{ !steps.target.outputs.pr }}
+          dry-run: ${{ inputs.dry-run == true }}
+          zulip-api-key: ${{ secrets.ZULIP_API_KEY }}
+          github-token: ${{ github.token }}
+
+  workflow-keepalive:
+    if: github.repository == 'digama0/lean4lean' && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1.2.1

--- a/.github/zulip-emoji-config.json
+++ b/.github/zulip-emoji-config.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Reconcile config for digama0/lean4lean: open/closed/merged plus CI status, using standard unicode emoji. See docs/zulip-emoji-quickstart.md in leanprover-community/mathlib-ci for setup, and docs/zulip-emoji-reconcile.md there for the full schema.",
+
+  "github_repo": "digama0/lean4lean",
+
+  "zulip": {
+    "site": "https://leanprover.zulipchat.com",
+    "email": "leanprover-community-repo-update-bot@leanprover.zulipchat.com"
+  },
+
+  "channels": {
+    "pr_reviews": "lean4lean"
+  },
+
+  "states": [
+    {"name": "merged", "group": "pr", "priority": 30, "source": {"state": "merged"}, "emoji": "merge"},
+    {"name": "closed", "group": "pr", "priority": 20, "source": {"state": "closed"}, "emoji": "closed-pr", "emoji_code": "61293", "reaction_type": "realm_emoji"},
+
+    {"name": "ci-running", "group": "ci", "source": {"ci": "running"}, "emoji": "yellow"},
+    {"name": "ci-success", "group": "ci", "source": {"ci": "success"}, "emoji": "check"},
+    {"name": "ci-failure", "group": "ci", "source": {"ci": "failure"}, "emoji": "cross_mark"}
+  ]
+}


### PR DESCRIPTION
Adds the mathlib-ci [Zulip emoji reconciler](https://github.com/leanprover-community/mathlib-ci/blob/master/docs/zulip-emoji-reconcile.md) so PR state (open/closed/ merged) and CI status are mirrored as emoji reactions on Zulip messages that mention lean4lean PRs. 

Triggers: hourly sweep, manual dispatch, PR close/reopen events, and CI workflow runs.

Prepared with Claude code